### PR TITLE
Make three levels of severity for validation messages

### DIFF
--- a/subway_structure.py
+++ b/subway_structure.py
@@ -927,7 +927,7 @@ class Route:
             for ck in CONSTRUCTION_KEYS:
                 if ck in el['tags']:
                     city.warn(
-                        'An under construction {} {} in route. Consider '
+                        'Under construction {} {} in route. Consider '
                         'setting \'inactive\' role or removing construction attributes'.format(
                             m['role'] or 'feature', k
                         ),

--- a/subway_structure.py
+++ b/subway_structure.py
@@ -1748,7 +1748,8 @@ class City:
             ]
         )
         if self.found_tram_lines != self.num_tram_lines:
-            self.error(
+            log_function = self.error if self.found_tram_lines == 0 else self.notice
+            log_function(
                 'Found {} tram lines, expected {}'.format(
                     self.found_tram_lines, self.num_tram_lines
                 ),

--- a/v2h_templates.py
+++ b/v2h_templates.py
@@ -7,23 +7,24 @@ body {
   font-family: sans-serif;
   font-size: 12pt;
 }
+main {
+  margin: 0 auto;
+  max-width: 900px;
+}
 th {
   font-size: 10pt;
 }
 .errors {
   font-size: 10pt;
-  color: red;
-  margin-bottom: 1em;
+  color: #ED0000;
 }
 .warnings {
   font-size: 10pt;
   color: saddlebrown;
-  margin-bottom: 1em;
 }
 .notices {
   font-size: 10pt;
   color: darkblue;
-  margin-bottom: 1em;
 }
 .bold {
   font-weight: bold;
@@ -43,6 +44,58 @@ table {
 }
 tr:hover td:nth-child(n+2) {
     background: lightblue;
+    box-shadow: 0px 0px 5px lightblue;
+}
+td {
+  border-radius: 2px;
+}
+td div+div {
+    margin-top: 0.8em;
+}
+.tooltip {
+    font-weight: bold;
+    position: relative;
+    text-align: left;
+}
+.tooltip div {
+    display: inline-block;
+    width: 19px;
+}
+.tooltip:before {
+    content: attr(data-text);
+    position: absolute;
+    top: 100%;
+    transform: translateX(-50%);
+    margin-top: 14px;
+    width: 200px;
+    padding: 10px;
+    border-radius: 10px;
+    background: lightblue;
+    color: black;
+    text-align: center;
+    opacity: 0;
+    transition: .3s opacity;
+    visibility: hidden;
+    z-index: 10
+}
+.tooltip:after {
+    content: "";
+    position: absolute;
+    margin-top: -5px;
+    top: 100%;
+    transform: translateX(-50%);
+    border: 10px solid #000;
+    border-color: transparent transparent lightblue transparent;
+    visibility: hidden;
+    opacity: 0;
+    transition: .3s opacity
+}
+.tooltip:hover {
+    text-decoration: none
+}
+.tooltip:hover:before,.tooltip:hover:after {
+    opacity: 1;
+    visibility: visible
 }
 </style>
 '''
@@ -56,6 +109,7 @@ INDEX_HEADER = '''
 (s)
 </head>
 <body>
+<main>
 <h1>Subway Validation Results</h1>
 <p>Total good metro networks: {good_cities} of {total_cities}.</p>
 <p><a href="render.html">View on the map</a></p>
@@ -107,6 +161,7 @@ INDEX_COUNTRY = '''
 
 INDEX_FOOTER = '''
 </table>
+</main>
 <p>Produced by <a href="https://github.com/mapsme/subways">Subway Preprocessor</a> on {date}.
 See <a href="{google}">this spreadsheet</a> for the reference metro statistics and
 <a href="https://en.wikipedia.org/wiki/List_of_metro_systems#List">this wiki page</a> for a list
@@ -124,6 +179,7 @@ COUNTRY_HEADER = '''
 (s)
 </head>
 <body>
+<main>
 <h1>Subway Validation Results for {country}</h1>
 <p><a href="index.html">Return to the countries list</a>.</p>
 <table cellspacing="3" cellpadding="2">
@@ -163,23 +219,30 @@ COUNTRY_CITY = '''
 {end}
 <td class="color{=stations}">st: {stations_found} / {stations_expected}</td>
 <td class="color{=transfers}">int: {transfers_found} / {transfers_expected}</td>
-<td class="color{=entrances}">e: {unused_entrances}</td>
+<td class="color{=entrances}">ent: {unused_entrances}</td>
 </tr>
 <tr><td colspan="{?subways}6{end}{?overground}8{end}">
-<div class="errors">
+{?errors}
+<div class="errors"><div data-text="Network is invalid and not suitable for routing." class="tooltip">🛑 Errors</div>
 {errors}
 </div>
-<div class="warnings">
+{end}
+{?warnings}
+<div class="warnings"><div data-text="Problematic data but it's still possible to build routes." class="tooltip">⚠️ Warnings</div>
 {warnings}
 </div>
-<div class="notices">
+{end}
+{?notices}
+<div class="notices"><div data-text="Suspicious condition but not necessarily an error." class="tooltip">ℹ️ Notices</div>
 {notices}
+{end}
 </div>
 </td></tr>
 '''
 
 COUNTRY_FOOTER = '''
 </table>
+</main>
 <p>Produced by <a href="https://github.com/mapsme/subways">Subway Preprocessor</a> on {date}.</p>
 </body>
 </html>

--- a/v2h_templates.py
+++ b/v2h_templates.py
@@ -52,8 +52,8 @@ tr:hover td:nth-child(n+2) {
 td {
   border-radius: 2px;
 }
-td div+div {
-    margin-top: 0.8em;
+td > div {
+    margin-bottom: 0.8em;
 }
 .tooltip {
     font-weight: bold;
@@ -68,7 +68,7 @@ td div+div {
     content: attr(data-text);
     position: absolute;
     top: 100%;
-    transform: translateX(-50%);
+    left: 0;
     margin-top: 14px;
     width: 200px;
     padding: 10px;
@@ -86,7 +86,7 @@ td div+div {
     position: absolute;
     margin-top: -5px;
     top: 100%;
-    transform: translateX(-50%);
+    left: 30px;
     border: 10px solid #000;
     border-color: transparent transparent lightblue transparent;
     visibility: hidden;

--- a/v2h_templates.py
+++ b/v2h_templates.py
@@ -12,10 +12,15 @@ th {
 }
 .errors {
   font-size: 10pt;
-  color: darkred;
+  color: red;
   margin-bottom: 1em;
 }
 .warnings {
+  font-size: 10pt;
+  color: saddlebrown;
+  margin-bottom: 1em;
+}
+.notices {
   font-size: 10pt;
   color: darkblue;
   margin-bottom: 1em;
@@ -69,6 +74,7 @@ INDEX_CONTINENT = '''
 <th>Interchanges</th>
 <th>Errors</th>
 <th>Warnings</th>
+<th>Notices</th>
 </tr>
 <tr>
 <td colspan="2" class="bold color{=cities}">{continent}</td>
@@ -79,6 +85,7 @@ INDEX_CONTINENT = '''
 <td class="color{=transfers}">{transfers_found} / {transfers_expected}</td>
 <td class="color{=errors}">{num_errors}</td>
 <td class="color{=warnings}">{num_warnings}</td>
+<td class="color{=notices}">{num_notices}</td>
 </tr>
 {content}
 '''
@@ -94,6 +101,7 @@ INDEX_COUNTRY = '''
 <td class="color{=transfers}">{transfers_found} / {transfers_expected}</td>
 <td class="color{=errors}">{num_errors}</td>
 <td class="color{=warnings}">{num_warnings}</td>
+<td class="color{=notices}">{num_notices}</td>
 </tr>
 '''
 
@@ -160,8 +168,12 @@ COUNTRY_CITY = '''
 <tr><td colspan="{?subways}6{end}{?overground}8{end}">
 <div class="errors">
 {errors}
-</div><div class="warnings">
+</div>
+<div class="warnings">
 {warnings}
+</div>
+<div class="notices">
+{notices}
 </div>
 </td></tr>
 '''

--- a/validation_to_html.py
+++ b/validation_to_html.py
@@ -18,6 +18,7 @@ class CityData:
             'total_cities': 1 if city else 0,
             'num_errors': 0,
             'num_warnings': 0,
+            'num_notices': 0
         }
         self.slug = None
         if city:
@@ -26,10 +27,12 @@ class CityData:
             self.continent = city['continent']
             self.errors = city['errors']
             self.warnings = city['warnings']
+            self.notices = city['notices']
             if not self.errors:
                 self.data['good_cities'] = 1
             self.data['num_errors'] = len(self.errors)
             self.data['num_warnings'] = len(self.warnings)
+            self.data['num_notices'] = len(self.notices)
             for k, v in city.items():
                 if 'found' in k or 'expected' in k or 'unused' in k:
                     self.data[k] = v
@@ -77,7 +80,7 @@ class CityData:
         s = s.replace(
             '{=entrances}', test_eq(self.data['unused_entrances'], 0)
         )
-        for k in ('errors', 'warnings'):
+        for k in ('errors', 'warnings', 'notices'):
             s = s.replace('{=' + k + '}', test_eq(self.data['num_' + k], 0))
         return s
 
@@ -195,8 +198,9 @@ for continent in sorted(continents.keys()):
                     if os.path.exists(file_base + '.geojson')
                     else None
                 )
-                e = '<br>'.join([osm_links(esc(e)) for e in city.errors])
-                w = '<br>'.join([osm_links(esc(w)) for w in city.warnings])
+                errors = '<br>'.join([osm_links(esc(e)) for e in city.errors])
+                warnings = '<br>'.join([osm_links(esc(w)) for w in city.warnings])
+                notices = '<br>'.join([osm_links(esc(n)) for n in city.notices])
                 country_file.write(
                     tmpl(
                         COUNTRY_CITY,
@@ -207,8 +211,9 @@ for continent in sorted(continents.keys()):
                         yaml=yaml_file,
                         json=json_file,
                         subways=not overground,
-                        errors=e,
-                        warnings=w,
+                        errors=errors,
+                        warnings=warnings,
+                        notices=notices,
                         overground=overground,
                     )
                 )


### PR DESCRIPTION
Add 'notice' severity level for validation messages. From now on the validation message levels are:

- **error** — the network is invalid and would not be added to the routing json file defined by `-o` option of `scripts/process_subways.py` script. Examples: wrong station count, stop_position not connected to a station.
- **warning** — there is an error in data but it's still possible to build routes. Examples: hole in route rails, an under construction rail in route.
- **notice** — suspicious condition but not necessarily an error. Example: route has different colour from master.