### PR TITLE
Suggest the parent route of platform with invalid role

### DIFF
--- a/subway_structure.py
+++ b/subway_structure.py
@@ -534,10 +534,10 @@ class RouteStop:
             else:
                 if role != 'platform' and 'stop' not in role:
                     city.warn(
-                        "Platform with invalid role '{}' in a route".format(
-                            role
+                        "Platform \"{}\" ({}) with invalid role '{}' in route".format(
+                            el['tags'].get('name', ''), el_id(el), role,
                         ),
-                        el,
+                        relation,
                     )
                 multiple_check = self.seen_platform
                 self.seen_platform_entry = True


### PR DESCRIPTION
The wraning message now looks like: 
`Platform "" (w1055889735) with invalid role '' in route (relation 2336456, "")`
It will be easier for us to sort those issues.