### PR TITLE
Truncate leading and trailing rails

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,39 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python application
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.6"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with unittest
+      run: |
+        python -m unittest discover tests

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ a city's bbox has been extended.
 A single city or a country with few metro networks can be validated much faster
 if you allow the `process_subway.py` to fetch data from Overpass API. Here are the steps:
 
-1. Python3 interpreter required (3.5+)
+1. Python3 interpreter required (3.6+)
 2. Clone the repo
     ```
     git clone https://github.com/alexey-zakharenkov/subways.git subways_validator

--- a/process_subways.py
+++ b/process_subways.py
@@ -408,7 +408,7 @@ if __name__ == '__main__':
     ):
         option_name = f"output_{processor_name}"
 
-        if not hasattr(options, option_name):
+        if not getattr(options, option_name, None):
             continue
 
         filename = getattr(options, option_name)

--- a/process_subways.py
+++ b/process_subways.py
@@ -336,7 +336,7 @@ if __name__ == '__main__':
             c.error("Validation logic error: {}".format(str(e)))
         else:
             c.validate()
-            if c.is_good():
+            if c.is_good:
                 good_cities.append(c)
 
     logging.info('Finding transfer stations')

--- a/processors/gtfs.py
+++ b/processors/gtfs.py
@@ -238,7 +238,10 @@ def process(cities, transfers, filename, cache_path):
                 }
                 gtfs_data["trips"].append(dict_to_row(trip, "trips"))
 
-                for i, (lon, lat) in enumerate(variant.tracks):
+                tracks = variant.get_extended_tracks()
+                tracks = variant.get_truncated_tracks(tracks)
+
+                for i, (lon, lat) in enumerate(tracks):
                     gtfs_data["shapes"].append(
                         dict_to_row(
                             {

--- a/processors/gtfs.py
+++ b/processors/gtfs.py
@@ -171,7 +171,7 @@ def process(cities, transfers, filename, cache_path):
     )
 
     all_stops = {}  # stop (stop area center or station) el_id -> stop data
-    good_cities = [c for c in cities if c.is_good()]
+    good_cities = [c for c in cities if c.is_good]
 
     def add_stop_gtfs(route_stop):
         """Add stop to all_stops.

--- a/processors/mapsme.py
+++ b/processors/mapsme.py
@@ -87,7 +87,7 @@ class MapsmeCache:
         # One stoparea may participate in routes of different cities
         self.stop_cities = defaultdict(set)  # stoparea id -> city names
         self.city_dict = {c.name: c for c in cities}
-        self.good_city_names = {c.name for c in cities if c.is_good()}
+        self.good_city_names = {c.name for c in cities if c.is_good}
 
     def _is_cached_city_usable(self, city):
         """Check if cached stations still exist in osm data and
@@ -118,7 +118,7 @@ class MapsmeCache:
         """Put stops and networks for bad cities into containers
         passed as arguments."""
         for city in self.city_dict.values():
-            if not city.is_good() and city.name in self.cache:
+            if not city.is_good and city.name in self.cache:
                 city_cached_data = self.cache[city.name]
                 if self._is_cached_city_usable(city):
                     stops.update(city_cached_data['stops'])
@@ -212,7 +212,7 @@ def process(cities, transfers, filename, cache_path):
     stop_areas = {}  # stoparea el_id -> StopArea instance
     stops = {}  # stoparea el_id -> stop jsonified data
     networks = []
-    good_cities = [c for c in cities if c.is_good()]
+    good_cities = [c for c in cities if c.is_good]
     platform_nodes = {}
     cache.provide_stops_and_networks(stops, networks)
 

--- a/subway_io.py
+++ b/subway_io.py
@@ -282,7 +282,7 @@ def write_recovery_data(path, current_data, cities):
 
     data = current_data
     for city in cities:
-        if city.is_good():
+        if city.is_good:
             data[city.name] = make_city_recovery_data(city)
 
     try:

--- a/subway_io.py
+++ b/subway_io.py
@@ -138,7 +138,7 @@ def dump_yaml(city, f):
     write_yaml(result, f)
 
 
-def make_geojson(city, tracks=True):
+def make_geojson(city, include_tracks_geometry=True):
     transfers = set()
     for t in city.transfers:
         transfers.update(t)
@@ -147,36 +147,25 @@ def make_geojson(city, tracks=True):
     stops = set()
     for rmaster in city:
         for variant in rmaster:
-            if not tracks:
-                features.append(
-                    {
-                        'type': 'Feature',
-                        'geometry': {
-                            'type': 'LineString',
-                            'coordinates': [s.stop for s in variant],
-                        },
-                        'properties': {
-                            'ref': variant.ref,
-                            'name': variant.name,
-                            'stroke': variant.colour,
-                        },
-                    }
-                )
-            elif variant.tracks:
-                features.append(
-                    {
-                        'type': 'Feature',
-                        'geometry': {
-                            'type': 'LineString',
-                            'coordinates': variant.tracks,
-                        },
-                        'properties': {
-                            'ref': variant.ref,
-                            'name': variant.name,
-                            'stroke': variant.colour,
-                        },
-                    }
-                )
+            tracks = (
+                variant.get_extended_tracks()
+                if include_tracks_geometry
+                else [s.stop for s in variant]
+            )
+            features.append(
+                {
+                    'type': 'Feature',
+                    'geometry': {
+                        'type': 'LineString',
+                        'coordinates': tracks,
+                    },
+                    'properties': {
+                        'ref': variant.ref,
+                        'name': variant.name,
+                        'stroke': variant.colour,
+                    },
+                }
+            )
             for st in variant:
                 stops.add(st.stop)
                 stopareas.add(st.stoparea)

--- a/subway_structure.py
+++ b/subway_structure.py
@@ -1477,6 +1477,7 @@ class RouteMaster:
 
 class City:
     def __init__(self, city_data, overground=False):
+        self.validate_called = False
         self.errors = []
         self.warnings = []
         self.notices = []
@@ -1734,7 +1735,12 @@ class City:
     def __iter__(self):
         return iter(self.routes.values())
 
+    @property
     def is_good(self):
+        assert self.validate_called, (
+            "You mustn't refer to City.is_good property before calling "
+            "the City.validate() method."
+        )
         return len(self.errors) == 0
 
     def get_validation_result(self):
@@ -1971,6 +1977,8 @@ class City:
                 ['{} ({})'.format(k, v) for k, v in networks.items()]
             )
             self.notice('More than one network: {}'.format(n_str))
+
+        self.validate_called = True
 
 
 def find_transfers(elements, cities):

--- a/subway_structure.py
+++ b/subway_structure.py
@@ -1093,7 +1093,7 @@ class Route:
         first_stop_location = find_segment(self.stops[0].stop, tracks, 0)
         last_stop_location = find_segment(self.stops[-1].stop, tracks, 0)
 
-        if last_stop_location:
+        if last_stop_location != (None, None):
             seg2, u2 = last_stop_location
             if u2 == 0.0:
                 # Make seg2 the segment the last_stop_location is
@@ -1104,7 +1104,7 @@ class Route:
                 tracks = tracks[0:seg2 + 2]
             tracks[-1] = self.stops[-1].stop
 
-        if first_stop_location:
+        if first_stop_location != (None, None):
             seg1, u1 = first_stop_location
             if u1 == 1.0:
                 # Make seg1 the segment the first_stop_location is

--- a/tests/sample_data.py
+++ b/tests/sample_data.py
@@ -1,0 +1,1335 @@
+sample_networks = {
+    "Only 2 stations, no rails": {
+        "xml": """<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' version='1' lat='0.0' lon='0.0'>
+    <tag k='name' v='Station 1' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='2' version='1' lat='0.0' lon='1.0'>
+    <tag k='name' v='Station 2' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <relation id='1' version='1'>
+    <member type='node' ref='1' role='' />
+    <member type='node' ref='2' role='' />
+    <tag k='name' v='Forward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='2' version='1'>
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='1' role='' />
+    <tag k='name' v='Backward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='3' version='1'>
+    <member type='relation' ref='1' role='' />
+    <member type='relation' ref='2' role='' />
+    <tag k='ref' v='1' />
+    <tag k='route_master' v='subway' />
+    <tag k='type' v='route_master' />
+  </relation>
+</osm>
+""",
+        "station_count": 2,
+        "tracks": [],
+        "extended_tracks": [
+            (0.0, 0.0),
+            (1.0, 0.0),
+        ],
+        "truncated_tracks": [],
+    },
+
+    "Only 2 stations connected with rails": {
+        "xml": """<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' version='1' lat='0.0' lon='0.0'>
+    <tag k='name' v='Station 1' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='2' version='1' lat='0.0' lon='1.0'>
+    <tag k='name' v='Station 2' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <way id='1' version='1'>
+    <nd ref='1' />
+    <nd ref='2' />
+    <tag k='railway' v='subway' />
+  </way>
+  <relation id='1' version='1'>
+    <member type='node' ref='1' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='way' ref='1' role='' />
+    <tag k='name' v='Forward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='2' version='1'>
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='1' role='' />
+    <member type='way' ref='1' role='' />
+    <tag k='name' v='Backward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='3' version='1'>
+    <member type='relation' ref='1' role='' />
+    <member type='relation' ref='2' role='' />
+    <tag k='ref' v='1' />
+    <tag k='route_master' v='subway' />
+    <tag k='type' v='route_master' />
+  </relation>
+</osm>
+""",
+        "station_count": 2,
+        "tracks": [
+            (0.0, 0.0),
+            (1.0, 0.0),
+        ],
+        "extended_tracks": [
+            (0.0, 0.0),
+            (1.0, 0.0),
+        ],
+        "truncated_tracks": [
+            (0.0, 0.0),
+            (1.0, 0.0),
+        ],
+    },
+
+    "Only 6 stations, no rails": {
+        "xml": """<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' version='1' lat='0.0' lon='0.0'>
+    <tag k='name' v='Station 1' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='2' version='1' lat='0.0' lon='1.0'>
+    <tag k='name' v='Station 2' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='3' version='1' lat='0.0' lon='2.0'>
+    <tag k='name' v='Station 3' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='4' version='1' lat='0.0' lon='3.0'>
+    <tag k='name' v='Station 4' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='5' version='1' lat='0.0' lon='4.0'>
+    <tag k='name' v='Station 5' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='6' version='1' lat='0.0' lon='5.0'>
+    <tag k='name' v='Station 6' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <relation id='1' version='1'>
+    <member type='node' ref='1' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='5' role='' />
+    <member type='node' ref='6' role='' />
+    <tag k='name' v='Forward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='2' version='1'>
+    <member type='node' ref='6' role='' />
+    <member type='node' ref='5' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='1' role='' />
+    <tag k='name' v='Backward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='3' version='1'>
+    <member type='relation' ref='1' role='' />
+    <member type='relation' ref='2' role='' />
+    <tag k='ref' v='1' />
+    <tag k='route_master' v='subway' />
+    <tag k='type' v='route_master' />
+  </relation>
+</osm>
+""",
+        "station_count": 6,
+        "tracks": [],
+        "extended_tracks": [
+            (0.0, 0.0),
+            (1.0, 0.0),
+            (2.0, 0.0),
+            (3.0, 0.0),
+            (4.0, 0.0),
+            (5.0, 0.0),
+        ],
+        "truncated_tracks": [],
+    },
+
+    "One rail line connecting all stations": {
+        "xml": """<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' version='1' lat='0.0' lon='0.0'>
+    <tag k='name' v='Station 1' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='2' version='1' lat='0.0' lon='1.0'>
+    <tag k='name' v='Station 2' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='3' version='1' lat='0.0' lon='2.0'>
+    <tag k='name' v='Station 3' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='4' version='1' lat='0.0' lon='3.0'>
+    <tag k='name' v='Station 4' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='5' version='1' lat='0.0' lon='4.0'>
+    <tag k='name' v='Station 5' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='6' version='1' lat='0.0' lon='5.0'>
+    <tag k='name' v='Station 6' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <way id='1' version='1'>
+    <nd ref='1' />
+    <nd ref='2' />
+    <nd ref='3' />
+    <nd ref='4' />
+    <nd ref='5' />
+    <nd ref='6' />
+    <tag k='railway' v='subway' />
+  </way>
+  <relation id='1' version='1'>
+    <member type='node' ref='1' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='5' role='' />
+    <member type='node' ref='6' role='' />
+    <member type='way' ref='1' role='' />
+    <tag k='name' v='Forward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='2' version='1'>
+    <member type='node' ref='6' role='' />
+    <member type='node' ref='5' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='1' role='' />
+    <member type='way' ref='1' role='' />
+    <tag k='name' v='Backward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='3' version='1'>
+    <member type='relation' ref='1' role='' />
+    <member type='relation' ref='2' role='' />
+    <tag k='ref' v='1' />
+    <tag k='route_master' v='subway' />
+    <tag k='type' v='route_master' />
+  </relation>
+</osm>
+""",
+        "station_count": 6,
+        "tracks": [
+            (0.0, 0.0),
+            (1.0, 0.0),
+            (2.0, 0.0),
+            (3.0, 0.0),
+            (4.0, 0.0),
+            (5.0, 0.0),
+        ],
+        "extended_tracks": [
+            (0.0, 0.0),
+            (1.0, 0.0),
+            (2.0, 0.0),
+            (3.0, 0.0),
+            (4.0, 0.0),
+            (5.0, 0.0),
+        ],
+        "truncated_tracks": [
+            (0.0, 0.0),
+            (1.0, 0.0),
+            (2.0, 0.0),
+            (3.0, 0.0),
+            (4.0, 0.0),
+            (5.0, 0.0),
+        ],
+    },
+
+    "One rail line connecting all stations except the last": {
+        "xml": """<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' version='1' lat='0.0' lon='0.0'>
+    <tag k='name' v='Station 1' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='2' version='1' lat='0.0' lon='1.0'>
+    <tag k='name' v='Station 2' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='3' version='1' lat='0.0' lon='2.0'>
+    <tag k='name' v='Station 3' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='4' version='1' lat='0.0' lon='3.0'>
+    <tag k='name' v='Station 4' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='5' version='1' lat='0.0' lon='4.0'>
+    <tag k='name' v='Station 5' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='6' version='1' lat='0.0' lon='5.0'>
+    <tag k='name' v='Station 6' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <way id='1' version='1'>
+    <nd ref='1' />
+    <nd ref='2' />
+    <nd ref='3' />
+    <nd ref='4' />
+    <nd ref='5' />
+    <tag k='railway' v='subway' />
+  </way>
+  <relation id='1' version='1'>
+    <member type='node' ref='1' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='5' role='' />
+    <member type='node' ref='6' role='' />
+    <member type='way' ref='1' role='' />
+    <tag k='name' v='Forward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='2' version='1'>
+    <member type='node' ref='6' role='' />
+    <member type='node' ref='5' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='1' role='' />
+    <member type='way' ref='1' role='' />
+    <tag k='name' v='Backward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='3' version='1'>
+    <member type='relation' ref='1' role='' />
+    <member type='relation' ref='2' role='' />
+    <tag k='ref' v='1' />
+    <tag k='route_master' v='subway' />
+    <tag k='type' v='route_master' />
+  </relation>
+</osm>
+""",
+        "station_count": 6,
+        "tracks": [
+            (0.0, 0.0),
+            (1.0, 0.0),
+            (2.0, 0.0),
+            (3.0, 0.0),
+            (4.0, 0.0),
+        ],
+        "extended_tracks": [
+            (0.0, 0.0),
+            (1.0, 0.0),
+            (2.0, 0.0),
+            (3.0, 0.0),
+            (4.0, 0.0),
+            (5.0, 0.0),
+        ],
+        "truncated_tracks": [
+            (0.0, 0.0),
+            (1.0, 0.0),
+            (2.0, 0.0),
+            (3.0, 0.0),
+            (4.0, 0.0),
+        ],
+    },
+
+    "One rail line connecting all stations except the fist": {
+        "xml": """<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' version='1' lat='0.0' lon='0.0'>
+    <tag k='name' v='Station 1' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='2' version='1' lat='0.0' lon='1.0'>
+    <tag k='name' v='Station 2' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='3' version='1' lat='0.0' lon='2.0'>
+    <tag k='name' v='Station 3' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='4' version='1' lat='0.0' lon='3.0'>
+    <tag k='name' v='Station 4' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='5' version='1' lat='0.0' lon='4.0'>
+    <tag k='name' v='Station 5' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='6' version='1' lat='0.0' lon='5.0'>
+    <tag k='name' v='Station 6' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <way id='1' version='1'>
+    <nd ref='2' />
+    <nd ref='3' />
+    <nd ref='4' />
+    <nd ref='5' />
+    <nd ref='6' />
+    <tag k='railway' v='subway' />
+  </way>
+  <relation id='1' version='1'>
+    <member type='node' ref='1' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='5' role='' />
+    <member type='node' ref='6' role='' />
+    <member type='way' ref='1' role='' />
+    <tag k='name' v='Forward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='2' version='1'>
+    <member type='node' ref='6' role='' />
+    <member type='node' ref='5' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='1' role='' />
+    <member type='way' ref='1' role='' />
+    <tag k='name' v='Backward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='3' version='1'>
+    <member type='relation' ref='1' role='' />
+    <member type='relation' ref='2' role='' />
+    <tag k='ref' v='1' />
+    <tag k='route_master' v='subway' />
+    <tag k='type' v='route_master' />
+  </relation>
+</osm>
+""",
+        "station_count": 6,
+        "tracks": [
+            (1.0, 0.0),
+            (2.0, 0.0),
+            (3.0, 0.0),
+            (4.0, 0.0),
+            (5.0, 0.0),
+        ],
+        "extended_tracks": [
+            (0.0, 0.0),
+            (1.0, 0.0),
+            (2.0, 0.0),
+            (3.0, 0.0),
+            (4.0, 0.0),
+            (5.0, 0.0),
+        ],
+        "truncated_tracks": [
+            (1.0, 0.0),
+            (2.0, 0.0),
+            (3.0, 0.0),
+            (4.0, 0.0),
+            (5.0, 0.0),
+        ],
+    },
+
+    "One rail line connecting all stations except the fist and the last": {
+        "xml": """<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' version='1' lat='0.0' lon='0.0'>
+    <tag k='name' v='Station 1' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='2' version='1' lat='0.0' lon='1.0'>
+    <tag k='name' v='Station 2' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='3' version='1' lat='0.0' lon='2.0'>
+    <tag k='name' v='Station 3' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='4' version='1' lat='0.0' lon='3.0'>
+    <tag k='name' v='Station 4' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='5' version='1' lat='0.0' lon='4.0'>
+    <tag k='name' v='Station 5' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='6' version='1' lat='0.0' lon='5.0'>
+    <tag k='name' v='Station 6' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <way id='1' version='1'>
+    <nd ref='2' />
+    <nd ref='3' />
+    <nd ref='4' />
+    <nd ref='5' />
+    <tag k='railway' v='subway' />
+  </way>
+  <relation id='1' version='1'>
+    <member type='node' ref='1' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='5' role='' />
+    <member type='node' ref='6' role='' />
+    <member type='way' ref='1' role='' />
+    <tag k='name' v='Forward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='2' version='1'>
+    <member type='node' ref='6' role='' />
+    <member type='node' ref='5' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='1' role='' />
+    <member type='way' ref='1' role='' />
+    <tag k='name' v='Backward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='3' version='1'>
+    <member type='relation' ref='1' role='' />
+    <member type='relation' ref='2' role='' />
+    <tag k='ref' v='1' />
+    <tag k='route_master' v='subway' />
+    <tag k='type' v='route_master' />
+  </relation>
+</osm>
+""",
+        "station_count": 6,
+        "tracks": [
+            (1.0, 0.0),
+            (2.0, 0.0),
+            (3.0, 0.0),
+            (4.0, 0.0),
+        ],
+        "extended_tracks": [
+            (0.0, 0.0),
+            (1.0, 0.0),
+            (2.0, 0.0),
+            (3.0, 0.0),
+            (4.0, 0.0),
+            (5.0, 0.0),
+        ],
+        "truncated_tracks": [
+            (1.0, 0.0),
+            (2.0, 0.0),
+            (3.0, 0.0),
+            (4.0, 0.0),
+        ],
+    },
+
+    "One rail line connecting only 2 first stations": {
+        "xml": """<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' version='1' lat='0.0' lon='0.0'>
+    <tag k='name' v='Station 1' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='2' version='1' lat='0.0' lon='1.0'>
+    <tag k='name' v='Station 2' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='3' version='1' lat='0.0' lon='2.0'>
+    <tag k='name' v='Station 3' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='4' version='1' lat='0.0' lon='3.0'>
+    <tag k='name' v='Station 4' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='5' version='1' lat='0.0' lon='4.0'>
+    <tag k='name' v='Station 5' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='6' version='1' lat='0.0' lon='5.0'>
+    <tag k='name' v='Station 6' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <way id='1' version='1'>
+    <nd ref='1' />
+    <nd ref='2' />
+    <tag k='railway' v='subway' />
+  </way>
+  <relation id='1' version='1'>
+    <member type='node' ref='1' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='5' role='' />
+    <member type='node' ref='6' role='' />
+    <member type='way' ref='1' role='' />
+    <tag k='name' v='Forward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='2' version='1'>
+    <member type='node' ref='6' role='' />
+    <member type='node' ref='5' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='1' role='' />
+    <member type='way' ref='1' role='' />
+    <tag k='name' v='Backward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='3' version='1'>
+    <member type='relation' ref='1' role='' />
+    <member type='relation' ref='2' role='' />
+    <tag k='ref' v='1' />
+    <tag k='route_master' v='subway' />
+    <tag k='type' v='route_master' />
+  </relation>
+</osm>
+""",
+        "station_count": 6,
+        "tracks": [
+            (0.0, 0.0),
+            (1.0, 0.0),
+        ],
+        "extended_tracks": [
+            (0.0, 0.0),
+            (1.0, 0.0),
+            (2.0, 0.0),
+            (3.0, 0.0),
+            (4.0, 0.0),
+            (5.0, 0.0),
+        ],
+        "truncated_tracks": [
+            (0.0, 0.0),
+            (1.0, 0.0),
+        ],
+    },
+
+    "One rail line connecting only 2 last stations": {
+        "xml": """<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' version='1' lat='0.0' lon='0.0'>
+    <tag k='name' v='Station 1' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='2' version='1' lat='0.0' lon='1.0'>
+    <tag k='name' v='Station 2' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='3' version='1' lat='0.0' lon='2.0'>
+    <tag k='name' v='Station 3' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='4' version='1' lat='0.0' lon='3.0'>
+    <tag k='name' v='Station 4' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='5' version='1' lat='0.0' lon='4.0'>
+    <tag k='name' v='Station 5' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='6' version='1' lat='0.0' lon='5.0'>
+    <tag k='name' v='Station 6' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <way id='1' version='1'>
+    <nd ref='5' />
+    <nd ref='6' />
+    <tag k='railway' v='subway' />
+  </way>
+  <relation id='1' version='1'>
+    <member type='node' ref='1' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='5' role='' />
+    <member type='node' ref='6' role='' />
+    <member type='way' ref='1' role='' />
+    <tag k='name' v='Forward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='2' version='1'>
+    <member type='node' ref='6' role='' />
+    <member type='node' ref='5' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='1' role='' />
+    <member type='way' ref='1' role='' />
+    <tag k='name' v='Backward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='3' version='1'>
+    <member type='relation' ref='1' role='' />
+    <member type='relation' ref='2' role='' />
+    <tag k='ref' v='1' />
+    <tag k='route_master' v='subway' />
+    <tag k='type' v='route_master' />
+  </relation>
+</osm>
+""",
+        "station_count": 6,
+        "tracks": [
+            (4.0, 0.0),
+            (5.0, 0.0),
+        ],
+        "extended_tracks": [
+            (0.0, 0.0),
+            (1.0, 0.0),
+            (2.0, 0.0),
+            (3.0, 0.0),
+            (4.0, 0.0),
+            (5.0, 0.0),
+        ],
+        "truncated_tracks": [
+            (4.0, 0.0),
+            (5.0, 0.0),
+        ],
+    },
+
+    "One rail connecting all stations and protruding at both ends": {
+        "xml": """<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' version='1' lat='0.0' lon='0.0'>
+    <tag k='name' v='Station 1' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='2' version='1' lat='0.0' lon='1.0'>
+    <tag k='name' v='Station 2' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='3' version='1' lat='0.0' lon='2.0'>
+    <tag k='name' v='Station 3' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='4' version='1' lat='0.0' lon='3.0'>
+    <tag k='name' v='Station 4' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='5' version='1' lat='0.0' lon='4.0'>
+    <tag k='name' v='Station 5' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='6' version='1' lat='0.0' lon='5.0'>
+    <tag k='name' v='Station 6' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='11' version='1' lat='0.0' lon='-1.0'>
+  </node>
+  <node id='12' version='1' lat='0.0' lon='6.0'>
+  </node>
+  <way id='1' version='1'>
+    <nd ref='11' />
+    <nd ref='1' />
+    <nd ref='2' />
+    <nd ref='3' />
+    <nd ref='4' />
+    <nd ref='5' />
+    <nd ref='6' />
+    <nd ref='12' />
+    <tag k='railway' v='subway' />
+  </way>
+  <relation id='1' version='1'>
+    <member type='node' ref='1' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='5' role='' />
+    <member type='node' ref='6' role='' />
+    <member type='way' ref='1' role='' />
+    <tag k='name' v='Forward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='2' version='1'>
+    <member type='node' ref='6' role='' />
+    <member type='node' ref='5' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='1' role='' />
+    <member type='way' ref='1' role='' />
+    <tag k='name' v='Backward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='3' version='1'>
+    <member type='relation' ref='1' role='' />
+    <member type='relation' ref='2' role='' />
+    <tag k='ref' v='1' />
+    <tag k='route_master' v='subway' />
+    <tag k='type' v='route_master' />
+  </relation>
+</osm>
+""",
+        "station_count": 6,
+        "tracks": [
+            (-1.0, 0.0),
+            (0.0, 0.0),
+            (1.0, 0.0),
+            (2.0, 0.0),
+            (3.0, 0.0),
+            (4.0, 0.0),
+            (5.0, 0.0),
+            (6.0, 0.0),
+        ],
+        "extended_tracks": [
+            (-1.0, 0.0),
+            (0.0, 0.0),
+            (1.0, 0.0),
+            (2.0, 0.0),
+            (3.0, 0.0),
+            (4.0, 0.0),
+            (5.0, 0.0),
+            (6.0, 0.0),
+        ],
+        "truncated_tracks": [
+            (0.0, 0.0),
+            (1.0, 0.0),
+            (2.0, 0.0),
+            (3.0, 0.0),
+            (4.0, 0.0),
+            (5.0, 0.0),
+        ],
+    },
+
+    "Several rails with reversed order for backward route, connecting all stations and protruding at both ends": {
+        "xml": """<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' version='1' lat='0.0' lon='0.0'>
+    <tag k='name' v='Station 1' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='2' version='1' lat='0.0' lon='1.0'>
+    <tag k='name' v='Station 2' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='3' version='1' lat='0.0' lon='2.0'>
+    <tag k='name' v='Station 3' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='4' version='1' lat='0.0' lon='3.0'>
+    <tag k='name' v='Station 4' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='5' version='1' lat='0.0' lon='4.0'>
+    <tag k='name' v='Station 5' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='6' version='1' lat='0.0' lon='5.0'>
+    <tag k='name' v='Station 6' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='11' version='1' lat='0.0' lon='-1.0'>
+  </node>
+  <node id='12' version='1' lat='0.0' lon='6.0'>
+  </node>
+  <way id='1' version='1'>
+    <nd ref='2' />
+    <nd ref='1' />
+    <nd ref='11' />
+    <tag k='railway' v='subway' />
+  </way>
+  <way id='2' version='1' >
+    <nd ref='2' />
+    <nd ref='3' />
+    <nd ref='4' />
+    <nd ref='5' />
+    <nd ref='6' />
+    <nd ref='12' />
+    <tag k='railway' v='subway' />
+  </way>
+  <relation id='1' version='1'>
+    <member type='node' ref='1' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='5' role='' />
+    <member type='node' ref='6' role='' />
+    <member type='way' ref='1' role='' />
+    <member type='way' ref='2' role='' />
+    <tag k='name' v='Forward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='2' version='1'>
+    <member type='node' ref='6' role='' />
+    <member type='node' ref='5' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='1' role='' />
+    <member type='way' ref='1' role='' />
+    <member type='way' ref='2' role='' />
+    <tag k='name' v='Backward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='3' version='1'>
+    <member type='relation' ref='1' role='' />
+    <member type='relation' ref='2' role='' />
+    <tag k='ref' v='1' />
+    <tag k='route_master' v='subway' />
+    <tag k='type' v='route_master' />
+  </relation>
+</osm>
+""",
+        "station_count": 6,
+        "tracks": [
+            (-1.0, 0.0),
+            (0.0, 0.0),
+            (1.0, 0.0),
+            (2.0, 0.0),
+            (3.0, 0.0),
+            (4.0, 0.0),
+            (5.0, 0.0),
+            (6.0, 0.0),
+        ],
+        "extended_tracks": [
+            (-1.0, 0.0),
+            (0.0, 0.0),
+            (1.0, 0.0),
+            (2.0, 0.0),
+            (3.0, 0.0),
+            (4.0, 0.0),
+            (5.0, 0.0),
+            (6.0, 0.0),
+        ],
+        "truncated_tracks": [
+            (0.0, 0.0),
+            (1.0, 0.0),
+            (2.0, 0.0),
+            (3.0, 0.0),
+            (4.0, 0.0),
+            (5.0, 0.0),
+        ],
+    },
+
+    "One rail laying near all stations requiring station projecting, protruding at both ends": {
+        "xml": """<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' version='1' lat='0.0001' lon='0.0'>
+    <tag k='name' v='Station 1' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='2' version='1' lat='0.0001' lon='1.0'>
+    <tag k='name' v='Station 2' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='3' version='1' lat='0.0001' lon='2.0'>
+    <tag k='name' v='Station 3' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='4' version='1' lat='0.0001' lon='3.0'>
+    <tag k='name' v='Station 4' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='5' version='1' lat='0.0001' lon='4.0'>
+    <tag k='name' v='Station 5' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='6' version='1' lat='0.0001' lon='5.0'>
+    <tag k='name' v='Station 6' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='11' version='1' lat='0.0' lon='-1.0'>
+  </node>
+  <node id='12' version='1' lat='0.0' lon='6.0'>
+  </node>
+  <way id='1' version='1'>
+    <nd ref='11' />
+    <nd ref='12' />
+    <tag k='railway' v='subway' />
+  </way>
+  <relation id='1' version='1'>
+    <member type='node' ref='1' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='5' role='' />
+    <member type='node' ref='6' role='' />
+    <member type='way' ref='1' role='' />
+    <tag k='name' v='Forward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='2' version='1'>
+    <member type='node' ref='6' role='' />
+    <member type='node' ref='5' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='1' role='' />
+    <member type='way' ref='1' role='' />
+    <tag k='name' v='Backward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='3' version='1'>
+    <member type='relation' ref='1' role='' />
+    <member type='relation' ref='2' role='' />
+    <tag k='ref' v='1' />
+    <tag k='route_master' v='subway' />
+    <tag k='type' v='route_master' />
+  </relation>
+</osm>
+""",
+        "station_count": 6,
+        "tracks": [
+            (-1.0, 0.0),
+            (6.0, 0.0),
+        ],
+        "extended_tracks": [
+            (-1.0, 0.0),
+            (6.0, 0.0),
+        ],
+        "truncated_tracks": [
+            (0.0, 0.0),
+            (5.0, 0.0),
+        ],
+    },
+
+    "One rail laying near all stations except the first and last": {
+        "xml": """<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' version='1' lat='0.0001' lon='0.0'>
+    <tag k='name' v='Station 1' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='2' version='1' lat='0.0001' lon='1.0'>
+    <tag k='name' v='Station 2' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='3' version='1' lat='0.0001' lon='2.0'>
+    <tag k='name' v='Station 3' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='4' version='1' lat='0.0001' lon='3.0'>
+    <tag k='name' v='Station 4' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='5' version='1' lat='0.0001' lon='4.0'>
+    <tag k='name' v='Station 5' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='6' version='1' lat='0.0001' lon='5.0'>
+    <tag k='name' v='Station 6' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='11' version='1' lat='0.0' lon='1.0'>
+  </node>
+  <node id='12' version='1' lat='0.0' lon='4.0'>
+  </node>
+  <way id='1' version='1'>
+    <nd ref='11' />
+    <nd ref='12' />
+    <tag k='railway' v='subway' />
+  </way>
+  <relation id='1' version='1'>
+    <member type='node' ref='1' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='5' role='' />
+    <member type='node' ref='6' role='' />
+    <member type='way' ref='1' role='' />
+    <tag k='name' v='Forward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='2' version='1'>
+    <member type='node' ref='6' role='' />
+    <member type='node' ref='5' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='1' role='' />
+    <member type='way' ref='1' role='' />
+    <tag k='name' v='Backward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='3' version='1'>
+    <member type='relation' ref='1' role='' />
+    <member type='relation' ref='2' role='' />
+    <tag k='ref' v='1' />
+    <tag k='route_master' v='subway' />
+    <tag k='type' v='route_master' />
+  </relation>
+</osm>
+""",
+        "station_count": 6,
+        "tracks": [
+            (1.0, 0.0),
+            (4.0, 0.0),
+        ],
+        "extended_tracks": [
+            (0.0, 0.0001),
+            (1.0, 0.0),
+            (4.0, 0.0),
+            (5.0, 0.0001),
+        ],
+        "truncated_tracks": [
+            (1.0, 0.0),
+            (4.0, 0.0),
+        ],
+    },
+
+    "Circle route without rails": {
+        "xml": """<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' version='1' lat='0.0' lon='0.0'>
+    <tag k='name' v='Station 1' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='2' version='1' lat='1.0' lon='0.0'>
+    <tag k='name' v='Station 2' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='3' version='1' lat='1.0' lon='1.0'>
+    <tag k='name' v='Station 3' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='4' version='1' lat='0.0' lon='1.0'>
+    <tag k='name' v='Station 4' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <relation id='1' version='1'>
+    <member type='node' ref='1' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='1' role='' />
+    <tag k='name' v='Forward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='2' version='1'>
+    <member type='node' ref='1' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='1' role='' />
+    <tag k='name' v='Backward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+</osm>
+""",
+        "station_count": 4,
+        "tracks": [],
+        "extended_tracks": [
+            (0.0, 0.0),
+            (0.0, 1.0),
+            (1.0, 1.0),
+            (1.0, 0.0),
+            (0.0, 0.0),
+        ],
+        "truncated_tracks": [],
+    },
+
+    "Circle route with closed rail line connecting all stations": {
+        "xml": """<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' version='1' lat='0.0' lon='0.0'>
+    <tag k='name' v='Station 1' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='2' version='1' lat='1.0' lon='0.0'>
+    <tag k='name' v='Station 2' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='3' version='1' lat='1.0' lon='1.0'>
+    <tag k='name' v='Station 3' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='4' version='1' lat='0.0' lon='1.0'>
+    <tag k='name' v='Station 4' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <way id='1' version='1'>
+    <nd ref='1' />
+    <nd ref='2' />
+    <nd ref='3' />
+    <nd ref='4' />
+    <nd ref='1' />
+    <tag k='railway' v='subway' />
+  </way>
+  <relation id='1' version='1'>
+    <member type='node' ref='1' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='1' role='' />
+    <member type='way' ref='1' role='' />
+    <tag k='name' v='Forward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='2' version='1'>
+    <member type='node' ref='1' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='1' role='' />
+    <member type='way' ref='1' role='' />
+    <tag k='name' v='Backward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+</osm>
+""",
+        "station_count": 4,
+        "tracks": [
+            (0.0, 0.0),
+            (0.0, 1.0),
+            (1.0, 1.0),
+            (1.0, 0.0),
+            (0.0, 0.0),
+        ],
+        "extended_tracks": [
+            (0.0, 0.0),
+            (0.0, 1.0),
+            (1.0, 1.0),
+            (1.0, 0.0),
+            (0.0, 0.0),
+        ],
+        "truncated_tracks": [
+            (0.0, 0.0),
+            (0.0, 1.0),
+            (1.0, 1.0),
+            (1.0, 0.0),
+            (0.0, 0.0),
+        ],
+    },
+}

--- a/tests/test_build_tracks.py
+++ b/tests/test_build_tracks.py
@@ -1,0 +1,107 @@
+"""
+To perform tests manually, run this command from the top directory
+of the repository:
+
+> python -m unittest discover tests
+
+or simply
+
+> python -m unittest
+"""
+
+import io
+import unittest
+
+from subway_structure import City
+from subway_io import load_xml
+from tests.sample_data import sample_networks
+
+
+class TestOneRouteTracks(unittest.TestCase):
+    """Test tracks extending and truncating on one-route networks"""
+
+    STATION_COUNT_INDEX = 4
+    CITY_TEMPLATE = [
+        1,  # city id
+        "Null Island",  # name
+        "World",  # Country
+        "Africa",  # continent
+        None,  # station count. Would be taken from the sample network data under testing
+        1,  # subway line count
+        0,  # light rail line count
+        0,  # interchanges
+        "-179, -89, 179, 89",  # bbox
+    ]
+
+    def prepare_city_routes(self, network):
+        city_data = self.CITY_TEMPLATE.copy()
+        city_data[self.STATION_COUNT_INDEX] = network["station_count"]
+        city = City(city_data)
+        elements = load_xml(io.BytesIO(network["xml"].encode("utf-8")))
+        for el in elements:
+            city.add(el)
+        city.extract_routes()
+        city.validate()
+
+        self.assertTrue(city.is_good())
+
+        route_master = list(city.routes.values())[0]
+        variants = route_master.routes
+
+        fwd_route = [v for v in variants if v.name == "Forward"][0]
+        bwd_route = [v for v in variants if v.name == "Backward"][0]
+
+        return fwd_route, bwd_route
+
+    def _test_tracks_extending_for_network(self, network_data):
+        fwd_route, bwd_route = self.prepare_city_routes(network_data)
+
+        self.assertEqual(
+            fwd_route.tracks,
+            network_data["tracks"],
+            "Wrong tracks",
+        )
+        extended_tracks = fwd_route.get_extended_tracks()
+        self.assertEqual(
+            extended_tracks,
+            network_data["extended_tracks"],
+            "Wrong tracks after extending",
+        )
+
+        self.assertEqual(
+            bwd_route.tracks,
+            network_data["tracks"][::-1],
+            "Wrong backward tracks",
+        )
+        extended_tracks = bwd_route.get_extended_tracks()
+        self.assertEqual(
+            extended_tracks,
+            network_data["extended_tracks"][::-1],
+            "Wrong backward tracks after extending",
+        )
+
+    def _test_tracks_truncating_for_network(self, network_data):
+        fwd_route, bwd_route = self.prepare_city_routes(network_data)
+
+        truncated_tracks = fwd_route.get_truncated_tracks(fwd_route.tracks)
+        self.assertEqual(
+            truncated_tracks,
+            network_data["truncated_tracks"],
+            "Wrong tracks after truncating",
+        )
+        truncated_tracks = bwd_route.get_truncated_tracks(bwd_route.tracks)
+        self.assertEqual(
+            truncated_tracks,
+            network_data["truncated_tracks"][::-1],
+            "Wrong backward tracks after truncating",
+        )
+
+    def test_tracks_extending(self):
+        for network_name, network_data in sample_networks.items():
+            with self.subTest(msg=network_name):
+                self._test_tracks_extending_for_network(network_data)
+
+    def test_tracks_truncating(self):
+        for network_name, network_data in sample_networks.items():
+            with self.subTest(msg=network_name):
+                self._test_tracks_truncating_for_network(network_data)

--- a/tests/test_build_tracks.py
+++ b/tests/test_build_tracks.py
@@ -43,7 +43,7 @@ class TestOneRouteTracks(unittest.TestCase):
         city.extract_routes()
         city.validate()
 
-        self.assertTrue(city.is_good())
+        self.assertTrue(city.is_good)
 
         route_master = list(city.routes.values())[0]
         variants = route_master.routes

--- a/tests/test_build_tracks.py
+++ b/tests/test_build_tracks.py
@@ -20,22 +20,22 @@ from tests.sample_data import sample_networks
 class TestOneRouteTracks(unittest.TestCase):
     """Test tracks extending and truncating on one-route networks"""
 
-    STATION_COUNT_INDEX = 4
-    CITY_TEMPLATE = [
-        1,  # city id
-        "Null Island",  # name
-        "World",  # Country
-        "Africa",  # continent
-        None,  # station count. Would be taken from the sample network data under testing
-        1,  # subway line count
-        0,  # light rail line count
-        0,  # interchanges
-        "-179, -89, 179, 89",  # bbox
-    ]
+    CITY_TEMPLATE = {
+        "id": 1,
+        "name": "Null Island",
+        "country": "World",
+        "continent": "Africa",
+        "num_stations": None,  # Would be taken from the sample network data under testing
+        "num_lines": 1,
+        "num_light_lines": 0,
+        "num_interchanges": 0,
+        "bbox": "-179, -89, 179, 89",
+        "networks": "",
+    }
 
     def prepare_city_routes(self, network):
         city_data = self.CITY_TEMPLATE.copy()
-        city_data[self.STATION_COUNT_INDEX] = network["station_count"]
+        city_data["num_stations"] = network["station_count"]
         city = City(city_data)
         elements = load_xml(io.BytesIO(network["xml"].encode("utf-8")))
         for el in elements:


### PR DESCRIPTION
Added a function to extend OSM rail lines to include all stations at route start/end, and a function to truncate protruding rails. Applied rail extending to GeoJSON output which is used in validator rendering page; applied both functions to GTFS generation. Added tests for these functions.