### PR TITLE
Remove undue transfers from gtfs

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.6
+    - name: Set up Python 3.8
       uses: actions/setup-python@v3
       with:
-        python-version: "3.6"
+        python-version: "3.8"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ a city's bbox has been extended.
 A single city or a country with few metro networks can be validated much faster
 if you allow the `process_subway.py` to fetch data from Overpass API. Here are the steps:
 
-1. Python3 interpreter required (3.6+)
+1. Python3 interpreter required (3.8+)
 2. Clone the repo
     ```
     git clone https://github.com/alexey-zakharenkov/subways.git subways_validator

--- a/processors/gtfs.py
+++ b/processors/gtfs.py
@@ -2,6 +2,8 @@ import csv
 import io
 import zipfile
 
+from itertools import permutations
+
 from ._common import (
     DEFAULT_INTERVAL,
     format_colour,
@@ -346,19 +348,20 @@ def process(cities, transfers, filename, cache_path):
         for stoparea1 in stoparea_set:
             for stoparea2 in stoparea_set:
                 if stoparea1.id < stoparea2.id:
+                    stop1_id = f"{stoparea1.id}_st"
+                    stop2_id = f"{stoparea2.id}_st"
+                    if not {stop1_id, stop2_id}.issubset(all_stops):
+                        continue
                     transfer_time = TRANSFER_PENALTY + round(
                         distance(stoparea1.center, stoparea2.center)
                         / SPEED_ON_TRANSFER
                     )
-                    for id1, id2 in (
-                        (stoparea1.id, stoparea2.id),
-                        (stoparea2.id, stoparea1.id),
-                    ):
+                    for id1, id2 in permutations((stop1_id, stop2_id)):
                         gtfs_data["transfers"].append(
                             dict_to_row(
                                 {
-                                    "from_stop_id": f"{id1}_st",
-                                    "to_stop_id": f"{id2}_st",
+                                    "from_stop_id": id1,
+                                    "to_stop_id": id2,
                                     "transfer_type": 0,
                                     "min_transfer_time": transfer_time,
                                 },

--- a/tests/test_gtfs_processor.py
+++ b/tests/test_gtfs_processor.py
@@ -1,0 +1,60 @@
+import unittest
+
+from processors.gtfs import (
+    dict_to_row,
+    GTFS_COLUMNS,
+)
+
+
+class TestGTFS(unittest.TestCase):
+    """Test processors/gtfs.py"""
+
+    def test_dict_to_row(self):
+        """Test that absent or None values in a GTFS feature item
+        are converted by dict_to_row() function to empty strings
+        in right amount.
+        """
+
+        if GTFS_COLUMNS["trips"][:3] != ["route_id", "service_id", "trip_id"]:
+            raise RuntimeError("GTFS column names/order inconsistency")
+
+        test_trips = [
+            {
+                "description": "Absent keys",
+                "trip_data": {
+                    "route_id": 1,
+                    "service_id": "a",
+                    "trip_id": "tr_123",
+                },
+            },
+            {
+                "description": "None or absent keys",
+                "trip_data": {
+                    "route_id": 1,
+                    "service_id": "a",
+                    "trip_id": "tr_123",
+                    "trip_headsign": None,
+                    "trip_short_name": None,
+                    "route_pattern_id": None,
+                },
+            },
+            {
+                "description": "None, empty-string or absent keys",
+                "trip_data": {
+                    "route_id": 1,
+                    "service_id": "a",
+                    "trip_id": "tr_123",
+                    "trip_headsign": "",
+                    "trip_short_name": "",
+                    "route_pattern_id": None,
+                },
+            },
+        ]
+
+        answer = [1, "a", "tr_123"] + [""] * (len(GTFS_COLUMNS["trips"]) - 3)
+
+        for test_trip in test_trips:
+            with self.subTest(msg=test_trip["description"]):
+                self.assertEqual(
+                    dict_to_row(test_trip["trip_data"], "trips"), answer
+                )

--- a/tests/test_gtfs_processor.py
+++ b/tests/test_gtfs_processor.py
@@ -1,4 +1,4 @@
-import unittest
+from unittest import TestCase
 
 from processors.gtfs import (
     dict_to_row,
@@ -6,10 +6,10 @@ from processors.gtfs import (
 )
 
 
-class TestGTFS(unittest.TestCase):
+class TestGTFS(TestCase):
     """Test processors/gtfs.py"""
 
-    def test_dict_to_row(self):
+    def test__dict_to_row__Nones_and_absent_keys(self) -> None:
         """Test that absent or None values in a GTFS feature item
         are converted by dict_to_row() function to empty strings
         in right amount.
@@ -55,6 +55,42 @@ class TestGTFS(unittest.TestCase):
 
         for test_trip in test_trips:
             with self.subTest(msg=test_trip["description"]):
-                self.assertEqual(
+                self.assertListEqual(
                     dict_to_row(test_trip["trip_data"], "trips"), answer
+                )
+
+    def test__dict_to_row__numeric_values(self) -> None:
+        """Test that zero numeric values remain zeros in dict_to_row() function,
+        and not empty strings or None.
+        """
+
+        shapes = [
+            {
+                "description": "Numeric non-zeroes",
+                "shape_data": {
+                    "shape_id": 1,
+                    "shape_pt_lat": 55.3242425,
+                    "shape_pt_lon": -179.23242,
+                    "shape_pt_sequence": 133,
+                    "shape_dist_traveled": 1.2345,
+                },
+                "answer": [1, 55.3242425, -179.23242, 133, 1.2345],
+            },
+            {
+                "description": "Numeric zeroes and None keys",
+                "shape_data": {
+                    "shape_id": 0,
+                    "shape_pt_lat": 0.0,
+                    "shape_pt_lon": 0,
+                    "shape_pt_sequence": 0,
+                    "shape_dist_traveled": None,
+                },
+                "answer": [0, 0.0, 0, 0, ""],
+            },
+        ]
+
+        for shape in shapes:
+            with self.subTest(shape["description"]):
+                self.assertListEqual(
+                    dict_to_row(shape["shape_data"], "shapes"), shape["answer"]
                 )


### PR DESCRIPTION
* Before the PR, a transfer was added to GTFS even if only one of two stops participated in routes, which provided useless transfer records.
* CSV data generation design improved

**ATTENTION!!!**
Python 3.8 is required from now on.