### PR TITLE
Fix bug with stop projections

### DIFF
--- a/tests/sample_data.py
+++ b/tests/sample_data.py
@@ -44,6 +44,16 @@ sample_networks = {
             (1.0, 0.0),
         ],
         "truncated_tracks": [],
+        "forward": {
+            "first_stop_on_rails_index": 2,
+            "last_stop_on_rails_index": 1,
+            "positions_on_rails": [],
+        },
+        "backward": {
+            "first_stop_on_rails_index": 2,
+            "last_stop_on_rails_index": 1,
+            "positions_on_rails": [],
+        },
     },
 
     "Only 2 stations connected with rails": {
@@ -104,6 +114,16 @@ sample_networks = {
             (0.0, 0.0),
             (1.0, 0.0),
         ],
+        "forward": {
+            "first_stop_on_rails_index": 0,
+            "last_stop_on_rails_index": 1,
+            "positions_on_rails": [[0], [1]],
+        },
+        "backward": {
+            "first_stop_on_rails_index": 0,
+            "last_stop_on_rails_index": 1,
+            "positions_on_rails": [[0], [1]],
+        },
     },
 
     "Only 6 stations, no rails": {
@@ -183,6 +203,16 @@ sample_networks = {
             (5.0, 0.0),
         ],
         "truncated_tracks": [],
+        "forward": {
+            "first_stop_on_rails_index": 6,
+            "last_stop_on_rails_index": 5,
+            "positions_on_rails": [],
+        },
+        "backward": {
+            "first_stop_on_rails_index": 6,
+            "last_stop_on_rails_index": 5,
+            "positions_on_rails": [],
+        },
     },
 
     "One rail line connecting all stations": {
@@ -287,6 +317,16 @@ sample_networks = {
             (4.0, 0.0),
             (5.0, 0.0),
         ],
+        "forward": {
+            "first_stop_on_rails_index": 0,
+            "last_stop_on_rails_index": 5,
+            "positions_on_rails": [[0], [1], [2], [3], [4], [5]],
+        },
+        "backward": {
+            "first_stop_on_rails_index": 0,
+            "last_stop_on_rails_index": 5,
+            "positions_on_rails": [[0], [1], [2], [3], [4], [5]],
+        },
     },
 
     "One rail line connecting all stations except the last": {
@@ -388,6 +428,16 @@ sample_networks = {
             (3.0, 0.0),
             (4.0, 0.0),
         ],
+        "forward": {
+            "first_stop_on_rails_index": 0,
+            "last_stop_on_rails_index": 4,
+            "positions_on_rails": [[0], [1], [2], [3], [4]],
+        },
+        "backward": {
+            "first_stop_on_rails_index": 1,
+            "last_stop_on_rails_index": 5,
+            "positions_on_rails": [[0], [1], [2], [3], [4]],
+        },
     },
 
     "One rail line connecting all stations except the fist": {
@@ -489,6 +539,16 @@ sample_networks = {
             (4.0, 0.0),
             (5.0, 0.0),
         ],
+        "forward": {
+            "first_stop_on_rails_index": 1,
+            "last_stop_on_rails_index": 5,
+            "positions_on_rails": [[0], [1], [2], [3], [4]],
+        },
+        "backward": {
+            "first_stop_on_rails_index": 0,
+            "last_stop_on_rails_index": 4,
+            "positions_on_rails": [[0], [1], [2], [3], [4]],
+        },
     },
 
     "One rail line connecting all stations except the fist and the last": {
@@ -587,6 +647,16 @@ sample_networks = {
             (3.0, 0.0),
             (4.0, 0.0),
         ],
+        "forward": {
+            "first_stop_on_rails_index": 1,
+            "last_stop_on_rails_index": 4,
+            "positions_on_rails": [[0], [1], [2], [3]],
+        },
+        "backward": {
+            "first_stop_on_rails_index": 1,
+            "last_stop_on_rails_index": 4,
+            "positions_on_rails": [[0], [1], [2], [3]],
+        },
     },
 
     "One rail line connecting only 2 first stations": {
@@ -679,6 +749,16 @@ sample_networks = {
             (0.0, 0.0),
             (1.0, 0.0),
         ],
+        "forward": {
+            "first_stop_on_rails_index": 0,
+            "last_stop_on_rails_index": 1,
+            "positions_on_rails": [[0], [1]],
+        },
+        "backward": {
+            "first_stop_on_rails_index": 4,
+            "last_stop_on_rails_index": 5,
+            "positions_on_rails": [[0], [1]],
+        },
     },
 
     "One rail line connecting only 2 last stations": {
@@ -771,6 +851,16 @@ sample_networks = {
             (4.0, 0.0),
             (5.0, 0.0),
         ],
+        "forward": {
+            "first_stop_on_rails_index": 4,
+            "last_stop_on_rails_index": 5,
+            "positions_on_rails": [[0], [1]],
+        },
+        "backward": {
+            "first_stop_on_rails_index": 0,
+            "last_stop_on_rails_index": 1,
+            "positions_on_rails": [[0], [1]],
+        },
     },
 
     "One rail connecting all stations and protruding at both ends": {
@@ -885,6 +975,16 @@ sample_networks = {
             (4.0, 0.0),
             (5.0, 0.0),
         ],
+        "forward": {
+            "first_stop_on_rails_index": 0,
+            "last_stop_on_rails_index": 5,
+            "positions_on_rails": [[1], [2], [3], [4], [5], [6]],
+        },
+        "backward": {
+            "first_stop_on_rails_index": 0,
+            "last_stop_on_rails_index": 5,
+            "positions_on_rails": [[1], [2], [3], [4], [5], [6]],
+        },
     },
 
     "Several rails with reversed order for backward route, connecting all stations and protruding at both ends": {
@@ -1005,6 +1105,16 @@ sample_networks = {
             (4.0, 0.0),
             (5.0, 0.0),
         ],
+        "forward": {
+            "first_stop_on_rails_index": 0,
+            "last_stop_on_rails_index": 5,
+            "positions_on_rails": [[1], [2], [3], [4], [5], [6]],
+        },
+        "backward": {
+            "first_stop_on_rails_index": 0,
+            "last_stop_on_rails_index": 5,
+            "positions_on_rails": [[1], [2], [3], [4], [5], [6]],
+        },
     },
 
     "One rail laying near all stations requiring station projecting, protruding at both ends": {
@@ -1097,6 +1207,16 @@ sample_networks = {
             (0.0, 0.0),
             (5.0, 0.0),
         ],
+        "forward": {
+            "first_stop_on_rails_index": 0,
+            "last_stop_on_rails_index": 5,
+            "positions_on_rails": [[1/7], [2/7], [3/7], [4/7], [5/7], [6/7]],
+        },
+        "backward": {
+            "first_stop_on_rails_index": 0,
+            "last_stop_on_rails_index": 5,
+            "positions_on_rails": [[1/7], [2/7], [3/7], [4/7], [5/7], [6/7]],
+        },
     },
 
     "One rail laying near all stations except the first and last": {
@@ -1191,6 +1311,16 @@ sample_networks = {
             (1.0, 0.0),
             (4.0, 0.0),
         ],
+        "forward": {
+            "first_stop_on_rails_index": 1,
+            "last_stop_on_rails_index": 4,
+            "positions_on_rails": [[0], [1/3], [2/3], [1]],
+        },
+        "backward": {
+            "first_stop_on_rails_index": 1,
+            "last_stop_on_rails_index": 4,
+            "positions_on_rails": [[0], [1/3], [2/3], [1]],
+        },
     },
 
     "Circle route without rails": {
@@ -1250,6 +1380,16 @@ sample_networks = {
             (0.0, 0.0),
         ],
         "truncated_tracks": [],
+        "forward": {
+            "first_stop_on_rails_index": 5,
+            "last_stop_on_rails_index": 4,
+            "positions_on_rails": [],
+        },
+        "backward": {
+            "first_stop_on_rails_index": 5,
+            "last_stop_on_rails_index": 4,
+            "positions_on_rails": [],
+        },
     },
 
     "Circle route with closed rail line connecting all stations": {
@@ -1331,5 +1471,15 @@ sample_networks = {
             (1.0, 0.0),
             (0.0, 0.0),
         ],
+        "forward": {
+            "first_stop_on_rails_index": 0,
+            "last_stop_on_rails_index": 4,
+            "positions_on_rails": [[0, 4], [1], [2], [3], [0, 4]],
+        },
+        "backward": {
+            "first_stop_on_rails_index": 0,
+            "last_stop_on_rails_index": 4,
+            "positions_on_rails": [[0, 4], [1], [2], [3], [0, 4]],
+        },
     },
 }


### PR DESCRIPTION
In case the tracks of a route are directed opposite to stops order, the `positions_on_rails` were calculated incorrectly for `RouteStop`s. They should be recalculated after reversing the tracks. Fixed and tests added.