### PR TITLE
Clean requirements

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 black
+        pip install flake8==6.0.0 black==23.1.0
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,1 @@
-Flask==2.0.1
-kdtree==0.16
-lxml==4.6.3
-Shapely==1.7.1
-## The following requirements were added by pip freeze:
-click==8.0.1
-itsdangerous==2.0.1
-Jinja2==3.0.1
-MarkupSafe==2.0.1
-Werkzeug==2.0.1
+lxml==4.9.2

--- a/scripts/process_subways.sh
+++ b/scripts/process_subways.sh
@@ -91,7 +91,7 @@ function check_poly() {
       if [ -z "${POLY-}" -o ! -f "${POLY-}" ]; then
         POLY=${POLY:-$(mktemp "$TMPDIR/all-metro.XXXXXXXX.poly")}
         if [ -n "$("$PYTHON" -c "import shapely" 2>&1)" ]; then
-          "$PYTHON" -m pip install shapely
+          "$PYTHON" -m pip install shapely==1.7.1
         fi
         "$PYTHON" "$SUBWAYS_PATH"/make_all_metro_poly.py \
             ${CITIES_INFO_URL:+--cities-info-url "$CITIES_INFO_URL"} > "$POLY"

--- a/stop_areas/requirements.txt
+++ b/stop_areas/requirements.txt
@@ -1,0 +1,12 @@
+Flask==2.2.3
+kdtree==0.16
+lxml==4.9.2
+
+## The following requirements were added by pip freeze:
+click==8.1.3
+importlib-metadata==6.0.0
+itsdangerous==2.1.2
+Jinja2==3.1.2
+MarkupSafe==2.1.2
+Werkzeug==2.2.3
+zipp==3.13.0

--- a/subway_structure.py
+++ b/subway_structure.py
@@ -1040,7 +1040,6 @@ class Route:
         return stop_position_elements
 
     def process_tracks(self, stop_position_elements):
-
         tracks, line_nodes = self.build_longest_line()
 
         for stop_el in stop_position_elements:
@@ -1511,7 +1510,6 @@ class RouteMaster:
 
 
 class City:
-
     route_class = Route
 
     def __init__(self, city_data, overground=False):

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -40,7 +40,6 @@ class TestProjection(unittest.TestCase):
                         )
 
     def test_projection_on_horizontal_segments(self):
-
         points = [
             (-2, 0),
             (-1 - self.SHIFT, 0),


### PR DESCRIPTION
`process_subways.py` and `stop_areas/serve.py` are independent applications, so separate the requirements.
`shapely` package is needed only if `scripts/process_subways.sh` is used which is not always the case.
Also update package versions to the latest stable.