### PR TITLE
Check CSV numeric values on parsing network information

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.8
+    - name: Set up Python 3.11
       uses: actions/setup-python@v3
       with:
-        python-version: "3.8"
+        python-version: "3.11"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ a city's bbox has been extended.
 A single city or a country with few metro networks can be validated much faster
 if you allow the `process_subway.py` to fetch data from Overpass API. Here are the steps:
 
-1. Python3 interpreter required (3.8+)
+1. Python3 interpreter required (3.11+)
 2. Clone the repo
     ```
     git clone https://github.com/alexey-zakharenkov/subways.git subways_validator

--- a/tests/assets/networks_with_bad_values.csv
+++ b/tests/assets/networks_with_bad_values.csv
@@ -1,0 +1,12 @@
+#,City,Country,Region,Stations,Subway Lines,Light Rail +Monorail,Interchanges,"BBox (lon, lat)",Networks (opt.),Comment,Source,
+291,Moscow,Russia,Europe,335,14,3,66,,"subway,train:Московский метрополитен;МЦК;МЦД","No bbox - skip the city",
+,Moscow - Aeroexpress,Russia,Europe,22,0,3,0,"37.170,55.385,38.028,56.022",train:Аэроэкспресс,"No id - skip the city",https://aeroexpress.ru
+292,Nizhny Novgorod,Russia,Europe,16,2,0,,"43.759918,56.1662,44.13208,56.410862",,"No configuration errors",,,
+NBS,Novosibirsk,Russia,Europe,13,2,0,1,"82.774773,54.926747,83.059044,55.127864",,"Non-numeric ID",,,
+294,Saint Petersburg,Russia,Europe,72,,,,"30.0648,59.7509,30.5976,60.1292",,"Empty line counts - no problem at CSV parsing stage",,
+,,,,,,,,,,,,
+295,Samara,Russia,Europe,10x,1,0,0,"50.011826,53.094024,50.411453,53.384147",,"Non-numeric station count",,
+296,Volgograd,Russia,Europe,40,zero,2zero,0,"44.366704,48.636024,44.62302,48.81765",,"Non-numbers in subway and light_rail line counts",,
+297,Yekaterinburg,Russia,Europe,,1,0,0,"60.460854,56.730505,60.727272,56.920997",,"Empty station count",,
+,,,,,,,,,,,,
+

--- a/tests/test_prepare_cities.py
+++ b/tests/test_prepare_cities.py
@@ -1,0 +1,36 @@
+import inspect
+from pathlib import Path
+from unittest import TestCase
+
+from process_subways import prepare_cities
+
+
+class TestPrepareCities(TestCase):
+    def test_prepare_cities(self) -> None:
+        csv_path = (
+            Path(inspect.getfile(self.__class__)).parent
+            / "assets"
+            / "networks_with_bad_values.csv"
+        )
+
+        cities = prepare_cities(cities_info_url=f"file://{csv_path}")
+
+        city_errors = {city.name: sorted(city.errors) for city in cities}
+
+        expected_errors = {
+            "Nizhny Novgorod": [],
+            "Novosibirsk": ["Configuration error: wrong value for id: NBS"],
+            "Saint Petersburg": [],
+            "Samara": [
+                "Configuration error: wrong value for num_stations: 10x"
+            ],
+            "Volgograd": [
+                "Configuration error: wrong value for num_light_lines: 2zero",
+                "Configuration error: wrong value for num_lines: zero",
+            ],
+            "Yekaterinburg": [
+                "Configuration error: wrong value for num_stations: <empty>"
+            ],
+        }
+
+        self.assertDictEqual(city_errors, expected_errors)


### PR DESCRIPTION
Solves #38 

In this PR:

- CSV (in particular, Google spreadsheet) values for integer numeric fields are checked. "Id" and "num_stations" fields are mandatory, line and interchange count fields may contain a number or be empty which means zero.
- Python version is raised to 3.11.