### PR TITLE
Fix validation message with python object representation

### DIFF
--- a/tests/sample_data_for_build_tracks.py
+++ b/tests/sample_data_for_build_tracks.py
@@ -37,7 +37,7 @@ sample_networks = {
   </relation>
 </osm>
 """,
-        "station_count": 2,
+        "num_stations": 2,
         "tracks": [],
         "extended_tracks": [
             (0.0, 0.0),
@@ -100,7 +100,7 @@ sample_networks = {
   </relation>
 </osm>
 """,
-        "station_count": 2,
+        "num_stations": 2,
         "tracks": [
             (0.0, 0.0),
             (1.0, 0.0),
@@ -190,7 +190,7 @@ sample_networks = {
   </relation>
 </osm>
 """,
-        "station_count": 6,
+        "num_stations": 6,
         "tracks": [],
         "extended_tracks": [
             (0.0, 0.0),
@@ -289,7 +289,7 @@ sample_networks = {
   </relation>
 </osm>
 """,
-        "station_count": 6,
+        "num_stations": 6,
         "tracks": [
             (0.0, 0.0),
             (1.0, 0.0),
@@ -401,7 +401,7 @@ sample_networks = {
   </relation>
 </osm>
 """,
-        "station_count": 6,
+        "num_stations": 6,
         "tracks": [
             (0.0, 0.0),
             (1.0, 0.0),
@@ -511,7 +511,7 @@ sample_networks = {
   </relation>
 </osm>
 """,
-        "station_count": 6,
+        "num_stations": 6,
         "tracks": [
             (1.0, 0.0),
             (2.0, 0.0),
@@ -620,7 +620,7 @@ sample_networks = {
   </relation>
 </osm>
 """,
-        "station_count": 6,
+        "num_stations": 6,
         "tracks": [
             (1.0, 0.0),
             (2.0, 0.0),
@@ -725,7 +725,7 @@ sample_networks = {
   </relation>
 </osm>
 """,
-        "station_count": 6,
+        "num_stations": 6,
         "tracks": [
             (0.0, 0.0),
             (1.0, 0.0),
@@ -826,7 +826,7 @@ sample_networks = {
   </relation>
 </osm>
 """,
-        "station_count": 6,
+        "num_stations": 6,
         "tracks": [
             (4.0, 0.0),
             (5.0, 0.0),
@@ -937,7 +937,7 @@ sample_networks = {
   </relation>
 </osm>
 """,
-        "station_count": 6,
+        "num_stations": 6,
         "tracks": [
             (-1.0, 0.0),
             (0.0, 0.0),
@@ -1069,7 +1069,7 @@ sample_networks = {
   </relation>
 </osm>
 """,
-        "station_count": 6,
+        "num_stations": 6,
         "tracks": [
             (-1.0, 0.0),
             (0.0, 0.0),
@@ -1189,7 +1189,7 @@ sample_networks = {
   </relation>
 </osm>
 """,
-        "station_count": 6,
+        "num_stations": 6,
         "tracks": [
             (-1.0, 0.0),
             (6.0, 0.0),
@@ -1304,7 +1304,7 @@ sample_networks = {
   </relation>
 </osm>
 """,
-        "station_count": 6,
+        "num_stations": 6,
         "tracks": [
             (1.0, 0.0),
             (4.0, 0.0),
@@ -1377,7 +1377,7 @@ sample_networks = {
   </relation>
 </osm>
 """,
-        "station_count": 4,
+        "num_stations": 4,
         "tracks": [],
         "extended_tracks": [
             (0.0, 0.0),
@@ -1455,7 +1455,7 @@ sample_networks = {
   </relation>
 </osm>
 """,
-        "station_count": 4,
+        "num_stations": 4,
         "tracks": [
             (0.0, 0.0),
             (0.0, 1.0),

--- a/tests/sample_data_for_error_messages.py
+++ b/tests/sample_data_for_error_messages.py
@@ -1,0 +1,316 @@
+sample_networks = {
+    "No errors": {
+        "xml": """<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' version='1' lat='0.0' lon='0.0'>
+    <tag k='name' v='Station 1' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='2' version='1' lat='0.0' lon='1.0'>
+    <tag k='name' v='Station 2' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <relation id='1' version='1'>
+    <member type='node' ref='1' role='' />
+    <member type='node' ref='2' role='' />
+    <tag k='name' v='Forward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='2' version='1'>
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='1' role='' />
+    <tag k='name' v='Backward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='3' version='1'>
+    <member type='relation' ref='1' role='' />
+    <member type='relation' ref='2' role='' />
+    <tag k='ref' v='1' />
+    <tag k='colour' v='red' />
+    <tag k='route_master' v='subway' />
+    <tag k='type' v='route_master' />
+  </relation>
+</osm>
+""",
+        "num_stations": 2,
+        "num_lines": 1,
+        "num_light_lines": 0,
+        "num_interchanges": 0,
+        "errors": [],
+        "warnings": [],
+        "notices": [],
+    },
+    "Bad station order": {
+        "xml": """<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' version='1' lat='0.0' lon='0.0'>
+    <tag k='name' v='Station 1' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='2' version='1' lat='0.0' lon='1.0'>
+    <tag k='name' v='Station 2' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='3' version='1' lat='0.0' lon='2.0'>
+    <tag k='name' v='Station 3' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='4' version='1' lat='0.0' lon='3.0'>
+    <tag k='name' v='Station 4' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <relation id='1' version='1'>
+    <member type='node' ref='1' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='4' role='' />
+    <tag k='name' v='Forward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='2' version='1'>
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='1' role='' />
+    <tag k='name' v='Backward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='3' version='1'>
+    <member type='relation' ref='1' role='' />
+    <member type='relation' ref='2' role='' />
+    <tag k='ref' v='1' />
+    <tag k='colour' v='red' />
+    <tag k='route_master' v='subway' />
+    <tag k='type' v='route_master' />
+  </relation>
+</osm>
+""",
+        "num_stations": 4,
+        "num_lines": 1,
+        "num_light_lines": 0,
+        "num_interchanges": 0,
+        "errors": [
+            'Angle between stops around "Station 3" (2.0, 0.0) '
+            'is too narrow, 0 degrees (relation 1, "Forward")',
+            'Angle between stops around "Station 2" (1.0, 0.0) '
+            'is too narrow, 0 degrees (relation 1, "Forward")',
+        ],
+        "warnings": [],
+        "notices": [],
+    },
+    "Angle < 20 degrees": {
+        "xml": """<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' version='1' lat='0.0' lon='0.0'>
+    <tag k='name' v='Station 1' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='2' version='1' lat='0.0' lon='1.0'>
+    <tag k='name' v='Station 2' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='3' version='1' lat='0.2' lon='0.0'>
+    <tag k='name' v='Station 3' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <relation id='1' version='1'>
+    <member type='node' ref='1' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='3' role='' />
+    <tag k='name' v='Forward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='2' version='1'>
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='1' role='' />
+    <member type='way' ref='1' role='' />
+    <tag k='name' v='Backward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='3' version='1'>
+    <member type='relation' ref='1' role='' />
+    <member type='relation' ref='2' role='' />
+    <tag k='ref' v='1' />
+    <tag k='colour' v='red' />
+    <tag k='route_master' v='subway' />
+    <tag k='type' v='route_master' />
+  </relation>
+</osm>
+""",
+        "num_stations": 3,
+        "num_lines": 1,
+        "num_light_lines": 0,
+        "num_interchanges": 0,
+        "errors": [
+            'Angle between stops around "Station 2" (1.0, 0.0) '
+            'is too narrow, 11 degrees (relation 1, "Forward")',
+            'Angle between stops around "Station 2" (1.0, 0.0) '
+            'is too narrow, 11 degrees (relation 2, "Backward")',
+        ],
+        "warnings": [],
+        "notices": [],
+    },
+    "Angle between 20 and 45 degrees": {
+        "xml": """<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' version='1' lat='0.0' lon='0.0'>
+    <tag k='name' v='Station 1' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='2' version='1' lat='0.0' lon='1.0'>
+    <tag k='name' v='Station 2' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='3' version='1' lat='0.5' lon='0.0'>
+    <tag k='name' v='Station 3' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <relation id='1' version='1'>
+    <member type='node' ref='1' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='3' role='' />
+    <tag k='name' v='Forward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='2' version='1'>
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='1' role='' />
+    <member type='way' ref='1' role='' />
+    <tag k='name' v='Backward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='3' version='1'>
+    <member type='relation' ref='1' role='' />
+    <member type='relation' ref='2' role='' />
+    <tag k='ref' v='1' />
+    <tag k='colour' v='red' />
+    <tag k='route_master' v='subway' />
+    <tag k='type' v='route_master' />
+  </relation>
+</osm>
+""",
+        "num_stations": 3,
+        "num_lines": 1,
+        "num_light_lines": 0,
+        "num_interchanges": 0,
+        "errors": [],
+        "warnings": [],
+        "notices": [
+            'Angle between stops around "Station 2" (1.0, 0.0) '
+            'is too narrow, 27 degrees (relation 1, "Forward")',
+            'Angle between stops around "Station 2" (1.0, 0.0) '
+            'is too narrow, 27 degrees (relation 2, "Backward")',
+        ],
+    },
+    "Stops unordered along tracks provided each angle > 45 degrees": {
+        "xml": """<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='1' version='1' lat='0.0' lon='0.0'>
+    <tag k='name' v='Station 1' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='2' version='1' lat='0.0' lon='1.0'>
+    <tag k='name' v='Station 2' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='3' version='1' lat='0.5' lon='0.0'>
+    <tag k='name' v='Station 3' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <node id='4' version='1' lat='1.0' lon='1.0'>
+    <tag k='name' v='Station 4' />
+    <tag k='railway' v='station' />
+    <tag k='station' v='subway' />
+  </node>
+  <way id='1' version='1'>
+    <nd ref='1' />
+    <nd ref='2' />
+    <nd ref='3' />
+    <tag k='railway' v='subway' />
+  </way>
+  <way id='2' version='1'>
+    <nd ref='3' />
+    <nd ref='4' />
+    <tag k='railway' v='subway' />
+  </way>
+  <relation id='1' version='1'>
+    <member type='node' ref='1' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='way' ref='1' role='' />
+    <member type='way' ref='2' role='' />
+    <tag k='name' v='Forward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='2' version='1'>
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='2' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='1' role='' />
+    <member type='way' ref='2' role='' />
+    <member type='way' ref='1' role='' />
+    <tag k='name' v='Backward' />
+    <tag k='ref' v='1' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='3' version='1'>
+    <member type='relation' ref='1' role='' />
+    <member type='relation' ref='2' role='' />
+    <tag k='ref' v='1' />
+    <tag k='colour' v='red' />
+    <tag k='route_master' v='subway' />
+    <tag k='type' v='route_master' />
+  </relation>
+</osm>
+""",
+        "num_stations": 4,
+        "num_lines": 1,
+        "num_light_lines": 0,
+        "num_interchanges": 0,
+        "errors": [
+            'Stops on tracks are unordered near "Station 2" (1.0, 0.0) '
+            '(relation 1, "Forward")',
+            'Stops on tracks are unordered near "Station 3" (0.0, 0.5) '
+            '(relation 2, "Backward")',
+        ],
+        "warnings": [],
+        "notices": [],
+    },
+}

--- a/tests/test_build_tracks.py
+++ b/tests/test_build_tracks.py
@@ -9,52 +9,16 @@ or simply
 > python -m unittest
 """
 
-import io
-import unittest
 
-from subway_structure import City
-from subway_io import load_xml
-from tests.sample_data import sample_networks
+from tests.sample_data_for_build_tracks import sample_networks
+from tests.util import TestCase
 
 
-class TestOneRouteTracks(unittest.TestCase):
+class TestOneRouteTracks(TestCase):
     """Test tracks extending and truncating on one-route networks"""
 
-    CITY_TEMPLATE = {
-        "id": 1,
-        "name": "Null Island",
-        "country": "World",
-        "continent": "Africa",
-        "num_stations": None,  # Would be taken from the sample network data
-        "num_lines": 1,
-        "num_light_lines": 0,
-        "num_interchanges": 0,
-        "bbox": "-179, -89, 179, 89",
-        "networks": "",
-    }
-
-    def assertListAlmostEqual(self, list1, list2, places=10) -> None:
-        if not (isinstance(list1, list) and isinstance(list2, list)):
-            raise RuntimeError(
-                f"Not lists passed to the '{self.__class__.__name__}."
-                "assertListAlmostEqual' method"
-            )
-        self.assertEqual(len(list1), len(list2))
-        for a, b in zip(list1, list2):
-            if isinstance(a, list) and isinstance(b, list):
-                self.assertListAlmostEqual(a, b, places)
-            else:
-                self.assertAlmostEqual(a, b, places)
-
     def prepare_city_routes(self, network) -> tuple:
-        city_data = self.CITY_TEMPLATE.copy()
-        city_data["num_stations"] = network["station_count"]
-        city = City(city_data)
-        elements = load_xml(io.BytesIO(network["xml"].encode("utf-8")))
-        for el in elements:
-            city.add(el)
-        city.extract_routes()
-        city.validate()
+        city = self.validate_city(network)
 
         self.assertTrue(city.is_good)
 

--- a/tests/test_error_messages.py
+++ b/tests/test_error_messages.py
@@ -1,0 +1,22 @@
+from tests.sample_data_for_error_messages import sample_networks
+from tests.util import TestCase
+
+
+class TestValidationMessages(TestCase):
+    """Test that the validator provides expected validation messages
+    on different types of errors in input OSM data.
+    """
+
+    def _test_validation_messages_for_network(self, network_data):
+        city = self.validate_city(network_data)
+
+        for err_level in ("errors", "warnings", "notices"):
+            self.assertListEqual(
+                sorted(getattr(city, err_level)),
+                sorted(network_data[err_level]),
+            )
+
+    def test_validation_messages(self) -> None:
+        for network_name, network_data in sample_networks.items():
+            with self.subTest(msg=network_name):
+                self._test_validation_messages_for_network(network_data)

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,49 @@
+import io
+from unittest import TestCase as unittestTestCase
+
+from subway_io import load_xml
+from subway_structure import City
+
+
+class TestCase(unittestTestCase):
+    """TestCase class for testing the Subway Validator"""
+
+    CITY_TEMPLATE = {
+        "id": 1,
+        "name": "Null Island",
+        "country": "World",
+        "continent": "Africa",
+        "bbox": "-179, -89, 179, 89",
+        "networks": "",
+        "num_stations": None,
+        "num_lines": 1,
+        "num_light_lines": 0,
+        "num_interchanges": 0,
+    }
+
+    def validate_city(self, network) -> City:
+        city_data = self.CITY_TEMPLATE.copy()
+        for attr in self.CITY_TEMPLATE.keys():
+            if attr in network:
+                city_data[attr] = network[attr]
+
+        city = City(city_data)
+        elements = load_xml(io.BytesIO(network["xml"].encode("utf-8")))
+        for el in elements:
+            city.add(el)
+        city.extract_routes()
+        city.validate()
+        return city
+
+    def assertListAlmostEqual(self, list1, list2, places=10) -> None:
+        if not (isinstance(list1, list) and isinstance(list2, list)):
+            raise RuntimeError(
+                f"Not lists passed to the '{self.__class__.__name__}."
+                "assertListAlmostEqual' method"
+            )
+        self.assertEqual(len(list1), len(list2))
+        for a, b in zip(list1, list2):
+            if isinstance(a, list) and isinstance(b, list):
+                self.assertListAlmostEqual(a, b, places)
+            else:
+                self.assertAlmostEqual(a, b, places)


### PR DESCRIPTION
* Show human readable text instead of python object representation in the "Angle between stops near <stop description> is too narrow" validation message.
    * Was: 
    Angle between stops around "RouteStop(stop=([pos](https://www.openstreetmap.org/search?query=55.8788071%2C37.4806188#map=18/55.8788071/37.4806188)), pl_entry=None, pl_exit=None, stoparea=StopArea(id=[r7889907](https://www.openstreetmap.org/relation/7889907), name=Ховрино, station=Station(id=[n5308689093](https://www.openstreetmap.org/node/5308689093), modes=subway, name=Ховрино, center=([pos](https://www.openstreetmap.org/search?query=55.8781525%2C37.4808537#map=18/55.8781525/37.4808537))), transfer=None, center=[37.480824222222225, 55.87821882222223]))" is too narrow, 11 degrees ([relation 14954440](https://www.openstreetmap.org/relation/14954440), "2")
    * Became:
    Angle between stops around "Ховрино" ([pos](https://www.openstreetmap.org/search?query=55.8788071%2C37.4806188#map=18/55.8788071/37.4806188)) is too narrow, 11 degrees ([relation 14954440](https://www.openstreetmap.org/relation/14954440), "2")
* Add tests for validation messages on wrong stops order.