### PR TITLE
Defer stop distances calculation until city is validated

### DIFF
--- a/process_subways.py
+++ b/process_subways.py
@@ -263,6 +263,7 @@ def validate_cities(cities: list[City]) -> list[City]:
         else:
             c.validate()
             if c.is_good:
+                c.calculate_distances()
                 good_cities.append(c)
 
     return good_cities

--- a/subway_structure.py
+++ b/subway_structure.py
@@ -1040,7 +1040,7 @@ class Route:
                     )
         return stop_position_elements
 
-    def process_tracks(self, stop_position_elements):
+    def process_tracks(self, stop_position_elements: list[dict]) -> None:
         tracks, line_nodes = self.build_longest_line()
 
         for stop_el in stop_position_elements:
@@ -1084,7 +1084,6 @@ class Route:
             projected_stops_data = self.project_stops_on_line()
             self.check_and_recover_stops_order(projected_stops_data)
             self.apply_projected_stops_data(projected_stops_data)
-            self.calculate_distances()
 
     def apply_projected_stops_data(self, projected_stops_data: dict) -> None:
         """Store better stop coordinates and indexes of first/last stops
@@ -2073,6 +2072,11 @@ class City:
             self.notice("More than one network: {}".format(n_str))
 
         self.validate_called = True
+
+    def calculate_distances(self) -> None:
+        for route_master in self:
+            for route in route_master:
+                route.calculate_distances()
 
 
 def find_transfers(elements, cities):


### PR DESCRIPTION
Stop distance from route beginning makes no sense for broken cities and is actually used for valid cities. After this PR, the distance calculation will be performed after validation stage only for good cities.