### PR TITLE
Mixin for comparison of json-like python structures

### DIFF
--- a/tests/test_build_tracks.py
+++ b/tests/test_build_tracks.py
@@ -1,8 +1,8 @@
 from tests.sample_data_for_build_tracks import metro_samples
-from tests.util import TestCase
+from tests.util import JsonLikeComparisonMixin, TestCase
 
 
-class TestOneRouteTracks(TestCase):
+class TestOneRouteTracks(JsonLikeComparisonMixin, TestCase):
     """Test tracks extending and truncating on one-route networks"""
 
     def prepare_city_routes(self, metro_sample: dict) -> tuple:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,11 +1,12 @@
 import json
+from operator import itemgetter
 
 from processors._common import transit_to_dict
 from tests.sample_data_for_outputs import metro_samples
-from tests.util import TestCase, TestTransitDataMixin
+from tests.util import JsonLikeComparisonMixin, TestCase
 
 
-class TestStorage(TestCase, TestTransitDataMixin):
+class TestStorage(JsonLikeComparisonMixin, TestCase):
     def test_storage(self) -> None:
         for sample in metro_samples:
             with self.subTest(msg=sample["name"]):
@@ -21,6 +22,21 @@ class TestStorage(TestCase, TestTransitDataMixin):
             map(tuple, control_transit_data["transfers"])
         )
 
-        self.compare_transit_data(
+        self._compare_transit_data(
             calculated_transit_data, control_transit_data
+        )
+
+    def _compare_transit_data(
+        self, transit_data1: dict, transit_data2: dict
+    ) -> None:
+        id_cmp = itemgetter("id")
+
+        self.assertMappingAlmostEqual(
+            transit_data1,
+            transit_data2,
+            unordered_lists={
+                "routes": id_cmp,
+                "itineraries": id_cmp,
+                "entrances": id_cmp,
+            },
         )

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,8 +1,7 @@
 import io
-from collections.abc import Sequence, Mapping
-from operator import itemgetter
+from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeAlias, Self
 from unittest import TestCase as unittestTestCase
 
 from process_subways import (
@@ -12,6 +11,8 @@ from process_subways import (
 )
 from subway_io import load_xml
 from subway_structure import City, find_transfers
+
+TestCaseMixin: TypeAlias = Self | unittestTestCase
 
 
 class TestCase(unittestTestCase):
@@ -75,41 +76,82 @@ class TestCase(unittestTestCase):
         transfers = find_transfers(elements, cities)
         return cities, transfers
 
+
+class JsonLikeComparisonMixin:
+    """Contains auxiliary methods for the TestCase class that allow
+    to compare json-like structures where some lists do not imply order
+    and actually represent sets.
+    Also, all collections compare floats with given precision to any nesting
+    depth.
+    """
+
     def _assertAnyAlmostEqual(
-        self,
+        self: TestCaseMixin,
         first: Any,
         second: Any,
         places: int = 10,
-        ignore_keys: set = None,
+        *,
+        unordered_lists: dict[str, Callable] | None = None,
+        ignore_keys: set[str] | None = None,
     ) -> None:
         """Dispatcher method to other "...AlmostEqual" methods
         depending on argument types.
+
+        Compare dictionaries/lists recursively, numeric values being compared
+        approximately.
+
+        :param: first  a value of arbitrary type, including collections
+        :param: second  a value of arbitrary type, including collections
+        :param: places  number of fractional digits. Is passed to
+                the self.assertAlmostEqual() method.
+        :param: unordered_lists  a dict whose keys are names of lists
+                to be compared without order, values - comparators for
+                the lists to sort them in an unambiguous order. If a comparator
+                is None, then the lists are compared as sets.
+        :param: ignore_keys  a set of strs with keys that should be ignored
+                during recursive comparison of dictionaries. May be used to
+                elaborate a custom comparison mechanism for some substructures.
+        :return: None
         """
-        if isinstance(first, Mapping):
-            self.assertMappingAlmostEqual(first, second, places, ignore_keys)
-        elif isinstance(first, Sequence) and not isinstance(
-            first, (str, bytes)
+        if all(isinstance(x, Mapping) for x in (first, second)):
+            self.assertMappingAlmostEqual(
+                first,
+                second,
+                places,
+                unordered_lists=unordered_lists,
+                ignore_keys=ignore_keys,
+            )
+        elif all(
+            isinstance(x, Sequence) and not isinstance(x, (str, bytes))
+            for x in (first, second)
         ):
-            self.assertSequenceAlmostEqual(first, second, places, ignore_keys)
-        else:
+            self.assertSequenceAlmostEqual(
+                first,
+                second,
+                places,
+                unordered_lists=unordered_lists,
+                ignore_keys=ignore_keys,
+            )
+        elif isinstance(first, float) and isinstance(second, float):
             self.assertAlmostEqual(first, second, places)
+        else:
+            self.assertEqual(first, second)
 
     def assertSequenceAlmostEqual(
-        self,
+        self: TestCaseMixin,
         seq1: Sequence,
         seq2: Sequence,
         places: int = 10,
-        ignore_keys: set = None,
+        *,
+        unordered_lists: dict[str, Callable] | None = None,
+        ignore_keys: set[str] | None = None,
     ) -> None:
         """Compare two sequences, items of numeric types being compared
         approximately, containers being approx-compared recursively.
 
-        :param: seq1  a sequence of values of any types, including collections
-        :param: seq2  a sequence of values of any types, including collections
-        :param: places  number of fractional digits (passed to
-                assertAlmostEqual() method of parent class)
-        :param: ignore_keys  a set of strs with keys in dictionaries
-                that should be ignored during recursive comparison
+        :param: places  see _assertAnyAlmostEqual() method
+        :param: unordered_lists  see _assertAnyAlmostEqual() method
+        :param: ignore_keys  see _assertAnyAlmostEqual() method
         :return: None
         """
         if not (isinstance(seq1, Sequence) and isinstance(seq2, Sequence)):
@@ -119,26 +161,99 @@ class TestCase(unittestTestCase):
             )
         self.assertEqual(len(seq1), len(seq2))
         for a, b in zip(seq1, seq2):
-            self._assertAnyAlmostEqual(a, b, places, ignore_keys)
+            self._assertAnyAlmostEqual(
+                a,
+                b,
+                places,
+                unordered_lists=unordered_lists,
+                ignore_keys=ignore_keys,
+            )
+
+    def assertSequenceAlmostEqualIgnoreOrder(
+        self: TestCaseMixin,
+        seq1: Sequence,
+        seq2: Sequence,
+        cmp: Callable | None,
+        places: int = 10,
+        *,
+        unordered_lists: dict[str, Callable] | None = None,
+        ignore_keys: set[str] | None = None,
+    ) -> None:
+        """Compares two sequences as sets, i.e. ignoring order. Nested
+        lists determined with unordered_lists parameter are also compared
+        without order.
+
+        :param: cmp  if None then compare sequences as sets. If elements are
+                     not hashable then this method is inapplicable and the
+                     sorted (with the comparator) sequences are compared.
+        :param: places  see _assertAnyAlmostEqual() method
+        :param: unordered_lists  see _assertAnyAlmostEqual() method
+        :param: ignore_keys  see _assertAnyAlmostEqual() method
+        :return: None
+        """
+        if cmp is not None:
+            v1 = sorted(seq1, key=cmp)
+            v2 = sorted(seq2, key=cmp)
+            self.assertSequenceAlmostEqual(
+                v1,
+                v2,
+                places,
+                unordered_lists=unordered_lists,
+                ignore_keys=ignore_keys,
+            )
+        else:
+            self.assertEqual(len(seq1), len(seq2))
+            v1 = set(seq1)
+            v2 = set(seq2)
+            self.assertSetEqual(v1, v2)
 
     def assertMappingAlmostEqual(
-        self,
+        self: TestCaseMixin,
         d1: Mapping,
         d2: Mapping,
         places: int = 10,
-        ignore_keys: set = None,
+        *,
+        unordered_lists: dict[str, Callable] | None = None,
+        ignore_keys: set[str] | None = None,
     ) -> None:
         """Compare dictionaries recursively, numeric values being compared
-        approximately.
+        approximately, some lists being compared without order.
 
-        :param: d1  a mapping of arbitrary key/value types,
-                including collections
-        :param: d1  a mapping of arbitrary key/value types,
-                including collections
-        :param: places  number of fractional digits (passed to
-                assertAlmostEqual() method of parent class)
-        :param: ignore_keys  a set of strs with keys in dictionaries
-                that should be ignored during recursive comparison
+        :param: places  see _assertAnyAlmostEqual() method
+        :param: unordered_lists  see _assertAnyAlmostEqual() method
+                Example 1:
+                        d1 = {
+                            "name_from_unordered_list": [a1, b1, c1],
+                            "some_other_name": [e1, f1, g1],
+                        }
+                        d2 = {
+                            "name_from_unordered_list": [a2, b2, c2],
+                            "some_other_name": [e2, f2, g2],
+                        }
+                Lists [a1, b1, c1] and [a2, b2, c2] will be compared
+                without order, lists [e1, f1, g1] and [e2, f2, g2] -
+                considering the order.
+
+                Example 2:
+                        d1 = {
+                            "name_from_unordered_list": {
+                                "key1": [a1, b1, c1],
+                                "key2": [e1, f1, g1],
+                            },
+                            "some_other_name": [h1, i1, k1],
+                        }
+                        d2 = {
+                            "name_from_unordered_list": {
+                                "key1": [a2, b2, c2],
+                                "key2": [e2, f2, g2],
+                            },
+                            "some_other_name": [h2, i2, k2],
+                        }
+                Lists [a1, b1, c1] and [a2, b2, c2] will be compared
+                without order, as well as [e1, f1, g1] and
+                [e2, f2, g2]; lists [h1, i1, k1] and [h2, i2, k2] -
+                considering the order.
+        :param: ignore_keys  see _assertAnyAlmostEqual() method
         :return: None
         """
         if not (isinstance(d1, Mapping) and isinstance(d2, Mapping)):
@@ -153,60 +268,42 @@ class TestCase(unittestTestCase):
             d1_keys -= ignore_keys
             d2_keys -= ignore_keys
         self.assertSetEqual(d1_keys, d2_keys)
+
+        if unordered_lists is None:
+            unordered_lists = {}
+
         for k in d1_keys:
             v1 = d1[k]
             v2 = d2[k]
-            self._assertAnyAlmostEqual(v1, v2, places, ignore_keys)
-
-
-class TestTransitDataMixin:
-    def compare_transit_data(self, td1: dict, td2: dict) -> None:
-        """Compare transit data td1 and td2 remembering that:
-        - arrays that represent sets ("routes", "itineraries", "entrances")
-          should be compared without order;
-        - all floating-point values (coordinates) should be compared
-          approximately.
-        """
-        self.assertMappingAlmostEqual(
-            td1,
-            td2,
-            ignore_keys={"stopareas", "routes", "itineraries"},
-        )
-
-        networks1 = td1["networks"]
-        networks2 = td2["networks"]
-
-        id_cmp = itemgetter("id")
-
-        for network_name, network_data1 in networks1.items():
-            network_data2 = networks2[network_name]
-            routes1 = sorted(network_data1["routes"], key=id_cmp)
-            routes2 = sorted(network_data2["routes"], key=id_cmp)
-            self.assertEqual(len(routes1), len(routes2))
-            for r1, r2 in zip(routes1, routes2):
-                self.assertMappingAlmostEqual(
-                    r1, r2, ignore_keys={"itineraries"}
+            if (cmp := unordered_lists.get(k, "")) == "" or not isinstance(
+                v1, (Sequence, Mapping)
+            ):
+                self._assertAnyAlmostEqual(
+                    v1,
+                    v2,
+                    places,
+                    unordered_lists=unordered_lists,
+                    ignore_keys=ignore_keys,
                 )
-                its1 = sorted(r1["itineraries"], key=id_cmp)
-                its2 = sorted(r2["itineraries"], key=id_cmp)
-                self.assertEqual(len(its1), len(its2))
-                for it1, it2 in zip(its1, its2):
-                    self.assertMappingAlmostEqual(it1, it2)
-
-        transfers1 = td1["transfers"]
-        transfers2 = td2["transfers"]
-        self.assertSetEqual(transfers1, transfers2)
-
-        stopareas1 = td1["stopareas"]
-        stopareas2 = td2["stopareas"]
-        self.assertMappingAlmostEqual(
-            stopareas1, stopareas2, ignore_keys={"entrances"}
-        )
-
-        for sa_id, sa1_data in stopareas1.items():
-            sa2_data = stopareas2[sa_id]
-            entrances1 = sorted(sa1_data["entrances"], key=id_cmp)
-            entrances2 = sorted(sa2_data["entrances"], key=id_cmp)
-            self.assertEqual(len(entrances1), len(entrances2))
-            for e1, e2 in zip(entrances1, entrances2):
-                self.assertMappingAlmostEqual(e1, e2)
+            elif isinstance(v1, Sequence):
+                self.assertSequenceAlmostEqualIgnoreOrder(
+                    v1,
+                    v2,
+                    cmp,
+                    places,
+                    unordered_lists=unordered_lists,
+                    ignore_keys=ignore_keys,
+                )
+            else:
+                self.assertSetEqual(set(v1.keys()), set(v2.keys()))
+                for ik in v1.keys():
+                    iv1 = v1[ik]
+                    iv2 = v2[ik]
+                    self.assertSequenceAlmostEqualIgnoreOrder(
+                        iv1,
+                        iv2,
+                        cmp,
+                        places,
+                        unordered_lists=unordered_lists,
+                        ignore_keys=ignore_keys,
+                    )


### PR DESCRIPTION
When testing, there is often a need to compare json-like structures where some lists do not imply order and actually represent sets. In this PR methods for comparison of such structures, with approximate float comparison, has been improved which has made tests more concise and clear.