### PR TITLE
Rewrite transfers generation

### DIFF
--- a/process_subways.py
+++ b/process_subways.py
@@ -490,7 +490,7 @@ def main() -> None:
     good_cities = validate_cities(cities)
 
     logging.info("Finding transfer stations")
-    transfers = find_transfers(osm, cities)
+    transfers = find_transfers(osm, good_cities)
 
     good_city_names = set(c.name for c in good_cities)
     logging.info(

--- a/processors/_common.py
+++ b/processors/_common.py
@@ -91,18 +91,17 @@ def transit_to_dict(
 
     # transfers
     pairwise_transfers = set()
-    for stoparea_set in transfers:
-        stoparea_list = list(stoparea_set)
-        for first_i in range(len(stoparea_list) - 1):
-            for second_i in range(first_i + 1, len(stoparea_list)):
-                stoparea1_id = stoparea_list[first_i].id
-                stoparea2_id = stoparea_list[second_i].id
+    for stoparea_id_set in transfers:
+        stoparea_ids = sorted(stoparea_id_set)
+        for first_i in range(len(stoparea_ids) - 1):
+            for second_i in range(first_i + 1, len(stoparea_ids)):
+                stoparea1_id = stoparea_ids[first_i]
+                stoparea2_id = stoparea_ids[second_i]
                 if all(
                     st_id in data["stopareas"]
                     for st_id in (stoparea1_id, stoparea2_id)
                 ):
-                    id1, id2 = sorted([stoparea1_id, stoparea2_id])
-                    pairwise_transfers.add((id1, id2))
+                    pairwise_transfers.add((stoparea1_id, stoparea2_id))
 
     data["transfers"] = pairwise_transfers
     return data

--- a/tests/sample_data_for_outputs.py
+++ b/tests/sample_data_for_outputs.py
@@ -21,6 +21,7 @@ metro_samples = [
             },
         ],
         "gtfs_dir": "assets/tiny_world_gtfs",
+        "transfers": [{"r1", "r2"}, {"r3", "r4"}],
         "json_dump": """
 {
   "stopareas": {
@@ -366,5 +367,320 @@ metro_samples = [
   ]
 }
 """,
+        "mapsme_output": {
+            "stops": [
+                {
+                    "name": "Station 1",
+                    "int_name": None,
+                    "lat": 0.0,
+                    "lon": 0.0,
+                    "osm_type": "node",
+                    "osm_id": 1,
+                    "id": 8,
+                    "entrances": [
+                        {
+                            "osm_type": "node",
+                            "osm_id": 1,
+                            "lon": 0.0,
+                            "lat": 0.0,
+                            "distance": 60,
+                        }
+                    ],
+                    "exits": [
+                        {
+                            "osm_type": "node",
+                            "osm_id": 1,
+                            "lon": 0.0,
+                            "lat": 0.0,
+                            "distance": 60,
+                        }
+                    ],
+                },
+                {
+                    "name": "Station 2",
+                    "int_name": None,
+                    "lat": 0.0047037307,
+                    "lon": 0.00470373068,
+                    "osm_type": "node",
+                    "osm_id": 2,
+                    "id": 14,
+                    "entrances": [
+                        {
+                            "osm_type": "node",
+                            "osm_id": 2,
+                            "lon": 0.0047209447,
+                            "lat": 0.004686516680000001,
+                            "distance": 60,
+                        }
+                    ],
+                    "exits": [
+                        {
+                            "osm_type": "node",
+                            "osm_id": 2,
+                            "lon": 0.0047209447,
+                            "lat": 0.004686516680000001,
+                            "distance": 60,
+                        }
+                    ],
+                },
+                {
+                    "name": "Station 3",
+                    "int_name": None,
+                    "lat": 0.0097589171,
+                    "lon": 0.01012040581,
+                    "osm_type": "node",
+                    "osm_id": 3,
+                    "id": 30,
+                    "entrances": [
+                        {
+                            "osm_type": "node",
+                            "osm_id": 201,
+                            "lon": 0.01007169217,
+                            "lat": 0.00967473055,
+                            "distance": 68,
+                        },
+                        {
+                            "osm_type": "node",
+                            "osm_id": 202,
+                            "lon": 0.01018702716,
+                            "lat": 0.00966936613,
+                            "distance": 69,
+                        },
+                    ],
+                    "exits": [
+                        {
+                            "osm_type": "node",
+                            "osm_id": 201,
+                            "lon": 0.01007169217,
+                            "lat": 0.00967473055,
+                            "distance": 68,
+                        },
+                        {
+                            "osm_type": "node",
+                            "osm_id": 202,
+                            "lon": 0.01018702716,
+                            "lat": 0.00966936613,
+                            "distance": 69,
+                        },
+                    ],
+                },
+                {
+                    "name": "Station 4",
+                    "int_name": None,
+                    "lat": 0.01,
+                    "lon": 0.0,
+                    "osm_type": "node",
+                    "osm_id": 4,
+                    "id": 32,
+                    "entrances": [
+                        {
+                            "osm_type": "node",
+                            "osm_id": 205,
+                            "lon": 0.000201163,
+                            "lat": 0.01015484596,
+                            "distance": 80,
+                        }
+                    ],
+                    "exits": [
+                        {
+                            "osm_type": "node",
+                            "osm_id": 205,
+                            "lon": 0.000201163,
+                            "lat": 0.01015484596,
+                            "distance": 80,
+                        }
+                    ],
+                },
+                {
+                    "name": "Station 5",
+                    "int_name": None,
+                    "lat": 0.00514739839,
+                    "lon": 0.0047718624,
+                    "osm_type": "node",
+                    "osm_id": 5,
+                    "id": 22,
+                    "entrances": [
+                        {
+                            "osm_type": "node",
+                            "osm_id": 5,
+                            "lon": 0.0047718624,
+                            "lat": 0.00514739839,
+                            "distance": 60,
+                        }
+                    ],
+                    "exits": [
+                        {
+                            "osm_type": "node",
+                            "osm_id": 5,
+                            "lon": 0.0047718624,
+                            "lat": 0.00514739839,
+                            "distance": 60,
+                        }
+                    ],
+                },
+                {
+                    "name": "Station 6",
+                    "int_name": None,
+                    "lat": 0.0,
+                    "lon": 0.01,
+                    "osm_type": "node",
+                    "osm_id": 6,
+                    "id": 48,
+                    "entrances": [
+                        {
+                            "osm_type": "node",
+                            "osm_id": 6,
+                            "lon": 0.01,
+                            "lat": 0.0,
+                            "distance": 60,
+                        }
+                    ],
+                    "exits": [
+                        {
+                            "osm_type": "node",
+                            "osm_id": 6,
+                            "lon": 0.01,
+                            "lat": 0.0,
+                            "distance": 60,
+                        }
+                    ],
+                },
+                {
+                    "name": "Station 7",
+                    "int_name": None,
+                    "lat": 0.010286367745,
+                    "lon": 0.009716854315,
+                    "osm_type": "node",
+                    "osm_id": 7,
+                    "id": 38,
+                    "entrances": [
+                        {
+                            "osm_type": "node",
+                            "osm_id": 203,
+                            "lon": 0.00959962338,
+                            "lat": 0.01042574907,
+                            "distance": 75,
+                        },
+                        {
+                            "osm_type": "node",
+                            "osm_id": 204,
+                            "lon": 0.00952183932,
+                            "lat": 0.01034796501,
+                            "distance": 76,
+                        },
+                    ],
+                    "exits": [
+                        {
+                            "osm_type": "node",
+                            "osm_id": 203,
+                            "lon": 0.00959962338,
+                            "lat": 0.01042574907,
+                            "distance": 75,
+                        },
+                        {
+                            "osm_type": "node",
+                            "osm_id": 204,
+                            "lon": 0.00952183932,
+                            "lat": 0.01034796501,
+                            "distance": 76,
+                        },
+                    ],
+                },
+                {
+                    "name": "Station 8",
+                    "int_name": None,
+                    "lat": 0.014377764559999999,
+                    "lon": 0.012405493905,
+                    "osm_type": "node",
+                    "osm_id": 8,
+                    "id": 134,
+                    "entrances": [
+                        {
+                            "osm_type": "node",
+                            "osm_id": 8,
+                            "lon": 0.012391026016666667,
+                            "lat": 0.01436273297,
+                            "distance": 60,
+                        }
+                    ],
+                    "exits": [
+                        {
+                            "osm_type": "node",
+                            "osm_id": 8,
+                            "lon": 0.012391026016666667,
+                            "lat": 0.01436273297,
+                            "distance": 60,
+                        }
+                    ],
+                },
+            ],
+            "transfers": [(14, 22, 81), (30, 38, 106)],
+            "networks": [
+                {
+                    "network": "Intersecting 2 metro lines",
+                    "routes": [
+                        {
+                            "type": "subway",
+                            "ref": "1",
+                            "name": "Blue Line",
+                            "colour": "0000ff",
+                            "route_id": 30,
+                            "itineraries": [
+                                {
+                                    "stops": [[8, 0], [14, 67], [30, 141]],
+                                    "interval": 150,
+                                },
+                                {
+                                    "stops": [[30, 0], [14, 74], [8, 141]],
+                                    "interval": 150,
+                                },
+                            ],
+                        },
+                        {
+                            "type": "subway",
+                            "ref": "2",
+                            "name": "Red Line",
+                            "colour": "ff0000",
+                            "route_id": 28,
+                            "itineraries": [
+                                {
+                                    "stops": [[32, 0], [22, 68], [48, 142]],
+                                    "interval": 150,
+                                },
+                                {
+                                    "stops": [[48, 0], [22, 74], [32, 142]],
+                                    "interval": 150,
+                                },
+                            ],
+                        },
+                    ],
+                    "agency_id": 1,
+                },
+                {
+                    "network": "One light rail line",
+                    "routes": [
+                        {
+                            "type": "light_rail",
+                            "ref": "LR",
+                            "name": "LR Line",
+                            "colour": "ffffff",
+                            "route_id": 22,
+                            "itineraries": [
+                                {
+                                    "stops": [[38, 0], [134, 49]],
+                                    "interval": 150,
+                                },
+                                {
+                                    "stops": [[134, 0], [38, 48]],
+                                    "interval": 150,
+                                },
+                            ],
+                            "casing": "a52a2a",
+                        }
+                    ],
+                    "agency_id": 2,
+                },
+            ],
+        },
     },
 ]

--- a/tests/test_find_transfers.py
+++ b/tests/test_find_transfers.py
@@ -1,0 +1,30 @@
+from copy import deepcopy
+
+from tests.sample_data_for_outputs import metro_samples
+from tests.util import TestCase, JsonLikeComparisonMixin
+
+
+class TestTransfers(JsonLikeComparisonMixin, TestCase):
+    """Test that the validator provides expected set of transfers."""
+
+    def _test__find_transfers__for_sample(self, metro_sample: dict) -> None:
+        cities, transfers = self.prepare_cities(metro_sample)
+        expected_transfers = metro_sample["transfers"]
+
+        self.assertSequenceAlmostEqualIgnoreOrder(
+            expected_transfers,
+            transfers,
+            cmp=lambda transfer_as_set: sorted(transfer_as_set),
+        )
+
+    def test__find_transfers(self) -> None:
+        sample1 = metro_samples[0]
+
+        sample2 = deepcopy(metro_samples[0])
+        # Make the second city invalid and thus exclude the inter-city transfer
+        sample2["cities_info"][1]["num_stations"] += 1
+        sample2["transfers"] = [{"r1", "r2"}]
+
+        for sample in sample1, sample2:
+            with self.subTest(msg=sample["name"]):
+                self._test__find_transfers__for_sample(sample)

--- a/tests/test_mapsme_processor.py
+++ b/tests/test_mapsme_processor.py
@@ -1,0 +1,53 @@
+from operator import itemgetter
+
+from processors.mapsme import transit_data_to_mapsme
+from tests.sample_data_for_outputs import metro_samples
+from tests.util import JsonLikeComparisonMixin, TestCase
+
+
+class TestMapsme(JsonLikeComparisonMixin, TestCase):
+    """Test processors/mapsme.py"""
+
+    def test__transit_data_to_mapsme(self) -> None:
+        for sample in metro_samples:
+            with self.subTest(msg=sample["name"]):
+                self._test__transit_data_to_mapsme__for_sample(sample)
+
+    def _test__transit_data_to_mapsme__for_sample(
+        self, metro_sample: dict
+    ) -> None:
+        cities, transfers = self.prepare_cities(metro_sample)
+        calculated_mapsme_data = transit_data_to_mapsme(
+            cities, transfers, cache_path=None
+        )
+        control_mapsme_data = metro_sample["mapsme_output"]
+
+        self.assertSetEqual(
+            set(control_mapsme_data.keys()),
+            set(calculated_mapsme_data.keys()),
+        )
+
+        self.assertSequenceAlmostEqualIgnoreOrder(
+            control_mapsme_data["stops"],
+            calculated_mapsme_data["stops"],
+            cmp=itemgetter("id"),
+            unordered_lists={
+                "entrances": lambda e: (e["osm_type"], e["osm_id"]),
+                "exits": lambda e: (e["osm_type"], e["osm_id"]),
+            },
+        )
+
+        self.assertSequenceAlmostEqualIgnoreOrder(
+            control_mapsme_data["transfers"],
+            calculated_mapsme_data["transfers"],
+        )
+
+        self.assertSequenceAlmostEqualIgnoreOrder(
+            control_mapsme_data["networks"],
+            calculated_mapsme_data["networks"],
+            cmp=itemgetter("network"),
+            unordered_lists={
+                "routes": itemgetter("route_id"),
+                "itineraries": lambda it: (it["stops"], it["interval"]),
+            },
+        )

--- a/tests/util.py
+++ b/tests/util.py
@@ -173,7 +173,7 @@ class JsonLikeComparisonMixin:
         self: TestCaseMixin,
         seq1: Sequence,
         seq2: Sequence,
-        cmp: Callable | None,
+        cmp: Callable | None = None,
         places: int = 10,
         *,
         unordered_lists: dict[str, Callable] | None = None,


### PR DESCRIPTION
- Return stoparea ids instead of references to instances when finding transfers. This is important because one OSM stoparea may result in multiple StopArea instances for different Cities, and when working with transfers we should not compare StopArea instances but their ids.
- Return transfers only for good cities
- Add tests on transfers and on MapsMe processor