### PR TITLE
Special searching for backward counterparts for circular routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ tmp_html/
 html/
 .idea
 .DS_Store
+.venv
 *.log
 *.json
 *.geojson

--- a/subway_io.py
+++ b/subway_io.py
@@ -88,7 +88,7 @@ def dump_yaml(city, f):
     routes = []
     for route in city:
         stations = OrderedDict(
-            [(sa.transfer or sa.id, sa.name) for sa in route.stop_areas()]
+            [(sa.transfer or sa.id, sa.name) for sa in route.stopareas()]
         )
         rte = {
             "type": route.mode,

--- a/tests/assets/route_masters.osm
+++ b/tests/assets/route_masters.osm
@@ -194,7 +194,7 @@
     <member type='node' ref='5' role='' />
     <member type='node' ref='1' role='' />
     <tag k='name' v='C: 1-3-5-1' />
-    <tag k='note' v='Circular route without backward' />
+    <tag k='note' v='Circular route without backward and without master' />
     <tag k='ref' v='C' />
     <tag k='colour' v='gray' />
     <tag k='route' v='subway' />
@@ -202,8 +202,8 @@
   </relation>
   <relation id='160' visible='true' version='1'>
     <member type='node' ref='1' role='' />
-    <member type='node' ref='3' role='' />
     <member type='node' ref='5' role='' />
+    <member type='node' ref='3' role='' />
     <member type='node' ref='1' role='' />
     <tag k='name' v='C2: 1-5-3-1' />
     <tag k='note' v='Circular route with backward' />
@@ -272,12 +272,27 @@
     <tag k='route' v='subway' />
     <tag k='type' v='route' />
   </relation>
-  <relation id='167' visible='true' version='1'>
-    <tag k='note' v='Empty route_master, so that it cannot be assigned to any city' />
-    <tag k='ref' v='06' />
+  <relation id='168' visible='true' version='1'>
+    <member type='node' ref='1' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='5' role='' />
+    <member type='node' ref='1' role='' />
     <tag k='colour' v='gray' />
-    <tag k='route_master' v='subway' />
-    <tag k='type' v='route_master' />
+    <tag k='name' v='C5: 1-3-5-1' />
+    <tag k='ref' v='C5' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
+  </relation>
+  <relation id='169' visible='true' version='1'>
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='5' role='' />
+    <member type='node' ref='1' role='' />
+    <member type='node' ref='3' role='' />
+    <tag k='colour' v='gray' />
+    <tag k='name' v='C5: 3-5-1-3' />
+    <tag k='ref' v='C5' />
+    <tag k='route' v='subway' />
+    <tag k='type' v='route' />
   </relation>
   <relation id='201' visible='true' version='1'>
     <member type='node' ref='21' role='' />
@@ -521,6 +536,22 @@
     <tag k='note' v='Empty route_master, but center can be calculated due to a spurious member' />
     <tag k='ref' v='07' />
     <tag k='colour' v='gray' />
+    <tag k='route_master' v='subway' />
+    <tag k='type' v='route_master' />
+  </relation>
+  <relation id='10025' visible='true' version='1'>
+    <member type='relation' ref='168' role='' />
+    <member type='relation' ref='169' role='' />
+    <tag k='colour' v='gray' />
+    <tag k='note' v='Two cirlucar routes with the same direction. Shloud generate notice &apos;no return direction&apos;' />
+    <tag k='ref' v='C5' />
+    <tag k='route_master' v='subway' />
+    <tag k='type' v='route_master' />
+  </relation>
+  <relation id='10026' visible='true' version='1'>
+    <tag k='colour' v='gray' />
+    <tag k='note' v='Empty route_master, so that it cannot be assigned to any city' />
+    <tag k='ref' v='06' />
     <tag k='route_master' v='subway' />
     <tag k='type' v='route_master' />
   </relation>

--- a/tests/assets/twin_routes.osm
+++ b/tests/assets/twin_routes.osm
@@ -288,10 +288,10 @@
   </relation>
   <relation id='160' visible='true' version='1'>
     <member type='node' ref='1' role='' />
-    <member type='node' ref='2' role='' />
-    <member type='node' ref='3' role='' />
-    <member type='node' ref='4' role='' />
     <member type='node' ref='5' role='' />
+    <member type='node' ref='4' role='' />
+    <member type='node' ref='3' role='' />
+    <member type='node' ref='2' role='' />
     <member type='node' ref='1' role='' />
     <tag k='name' v='C2: 1-5-4-3-2-1' />
     <tag k='note' v='Circular route with backward' />

--- a/tests/sample_data_for_error_messages.py
+++ b/tests/sample_data_for_error_messages.py
@@ -326,9 +326,9 @@ metro_samples = [
         "xml_file": "assets/route_masters.osm",
         "cities_info": [
             {
-                "num_stations": (3 + 3 + 3 + 5 + 3 + 3 + 4)
+                "num_stations": (3 + 3 + 3 + 5 + 3 + 3 + 4 + 3)
                 + (3 + 3 + 3 + 3 + 3 + 3 + 4),
-                "num_lines": 7 + 7,
+                "num_lines": 8 + 7,
                 "num_interchanges": 0 + 1,
             },
         ],
@@ -350,6 +350,8 @@ metro_samples = [
             'Route does not have a return direction (relation 209, "5: 1-2-3")',  # noqa: E501
             'Route does not have a return direction (relation 210, "5: 2-1")',  # noqa: E501
             'Only one route in route_master. Please check if it needs a return route (relation 213, "C3: 1-2-3-8-1")',  # noqa: E501
+            'Route does not have a return direction (relation 168, "C5: 1-3-5-1")',  # noqa: E501
+            'Route does not have a return direction (relation 169, "C5: 3-5-1-3")',  # noqa: E501
         ],
     },
 ]

--- a/tests/test_route_master.py
+++ b/tests/test_route_master.py
@@ -1,9 +1,97 @@
-from tests.util import TestCase
-
+from subway_structure import RouteMaster
 from tests.sample_data_for_twin_routes import metro_samples
+from tests.util import TestCase
 
 
 class TestRouteMaster(TestCase):
+    def test__find_common_circular_subsequence(self) -> None:
+        cases = [
+            {  # the 1st sequence is empty
+                "sequence1": [],
+                "sequence2": [1, 2, 3, 4],
+                "answer": [],
+            },
+            {  # the 2nd sequence is empty
+                "sequence1": [1, 2, 3, 4],
+                "sequence2": [],
+                "answer": [],
+            },
+            {  # equal sequences
+                "sequence1": [1, 2, 3, 4],
+                "sequence2": [1, 2, 3, 4],
+                "answer": [1, 2, 3, 4],
+            },
+            {  # one sequence is a cyclic shift of the other
+                "sequence1": [1, 2, 3, 4],
+                "sequence2": [4, 1, 2, 3],
+                "answer": [1, 2, 3, 4],
+            },
+            {  # the 2nd sequence is a subsequence of the 1st; equal ends
+                "sequence1": [1, 2, 3, 4],
+                "sequence2": [1, 2, 4],
+                "answer": [1, 2, 4],
+            },
+            {  # the 1st sequence is a subsequence of the 2nd; equal ends
+                "sequence1": [1, 2, 4],
+                "sequence2": [1, 2, 3, 4],
+                "answer": [1, 2, 4],
+            },
+            {  # the 2nd sequence is an innter subsequence of the 1st
+                "sequence1": [1, 2, 3, 4],
+                "sequence2": [2, 3],
+                "answer": [2, 3],
+            },
+            {  # the 1st sequence is an inner subsequence of the 2nd
+                "sequence1": [2, 3],
+                "sequence2": [1, 2, 3, 4],
+                "answer": [2, 3],
+            },
+            {  # the 2nd sequence is a continuation of the 1st
+                "sequence1": [1, 2, 3, 4],
+                "sequence2": [4, 5, 6],
+                "answer": [4],
+            },
+            {  # the 1st sequence is a continuation of the 2nd
+                "sequence1": [4, 5, 6],
+                "sequence2": [1, 2, 3, 4],
+                "answer": [4],
+            },
+            {  # no common elements
+                "sequence1": [1, 2, 3, 4],
+                "sequence2": [5, 6, 7],
+                "answer": [],
+            },
+            {  # one sequence is the reversed other
+                "sequence1": [1, 2, 3, 4],
+                "sequence2": [4, 3, 2, 1],
+                "answer": [1, 2],
+            },
+            {  # the 2nd is a subsequence of shifted 1st
+                "sequence1": [1, 2, 3, 4],
+                "sequence2": [2, 4, 1],
+                "answer": [1, 2, 4],
+            },
+            {  # the 1st is a subsequence of shifted 2nd
+                "sequence1": [2, 4, 1],
+                "sequence2": [1, 2, 3, 4],
+                "answer": [2, 4, 1],
+            },
+            {  # mixed case: few common elements
+                "sequence1": [1, 2, 4],
+                "sequence2": [2, 3, 4],
+                "answer": [2, 4],
+            },
+        ]
+
+        for i, case in enumerate(cases):
+            with self.subTest(f"case#{i}"):
+                self.assertListEqual(
+                    case["answer"],
+                    RouteMaster.find_common_circular_subsequence(
+                        case["sequence1"], case["sequence2"]
+                    ),
+                )
+
     def _test_find_twin_routes_for_network(self, metro_sample: dict) -> None:
         cities, transfers = self.prepare_cities(metro_sample)
         city = cities[0]


### PR DESCRIPTION
Solves #46.

Indeed, before Nov 27, 2023 the validator generated spurious notice _"Only one route in route_master. Please check if it needs a return route"_ for circular routes that started at different stations (like A-B-C-D-A and B-A-D-C-B) as if they had no return direction. After #44 the notice vanished, but it vanished at all for circular routes.

In this PR, the checking for return direction of circular routes is resumed, fixed and supplemented with tests.