### PR TITLE
Process route duration, i.e. average vehicle speed

### DIFF
--- a/subways/osm_element.py
+++ b/subways/osm_element.py
@@ -17,3 +17,10 @@ def el_center(el: OsmElementT) -> LonLat | None:
     elif "center" in el:
         return el["center"]["lon"], el["center"]["lat"]
     return None
+
+
+def get_network(relation: OsmElementT) -> str | None:
+    for k in ("network:metro", "network", "operator"):
+        if k in relation["tags"]:
+            return relation["tags"][k]
+    return None

--- a/subways/processors/_common.py
+++ b/subways/processors/_common.py
@@ -10,6 +10,7 @@ if typing.TYPE_CHECKING:
 
 DEFAULT_INTERVAL = 2.5 * 60  # seconds
 KMPH_TO_MPS = 1 / 3.6  # km/h to m/s conversion multiplier
+DEFAULT_AVE_VEHICLE_SPEED = 40 * KMPH_TO_MPS  # m/s
 SPEED_ON_TRANSFER = 3.5 * KMPH_TO_MPS  # m/s
 TRANSFER_PENALTY = 30  # seconds
 
@@ -52,6 +53,7 @@ def transit_to_dict(cities: list[City], transfers: TransfersT) -> dict:
                     "start_time": route.start_time,
                     "end_time": route.end_time,
                     "interval": route.interval,
+                    "duration": route.duration,
                     "stops": [
                         {
                             "stoparea_id": route_stop.stoparea.id,

--- a/subways/processors/gtfs.py
+++ b/subways/processors/gtfs.py
@@ -9,8 +9,10 @@ from tarfile import TarFile, TarInfo
 from zipfile import ZipFile
 
 from ._common import (
+    DEFAULT_AVE_VEHICLE_SPEED,
     DEFAULT_INTERVAL,
     format_colour,
+    KMPH_TO_MPS,
     SPEED_ON_TRANSFER,
     TRANSFER_PENALTY,
     transit_to_dict,
@@ -63,6 +65,7 @@ GTFS_COLUMNS = {
         "trip_route_type",
         "route_pattern_id",
         "bikes_allowed",
+        "average_speed",  # extension field (km/h)
     ],
     "stops": [
         "stop_id",
@@ -242,11 +245,22 @@ def transit_data_to_gtfs(data: dict) -> dict:
 
             for itinerary in route_master["itineraries"]:
                 shape_id = itinerary["id"][1:]  # truncate leading 'r'
+                average_speed = round(
+                    (
+                        DEFAULT_AVE_VEHICLE_SPEED
+                        if not itinerary["duration"]
+                        else itinerary["stops"][-1]["distance"]
+                        / itinerary["duration"]
+                    )
+                    / KMPH_TO_MPS,
+                    1,
+                )  # km/h
                 trip = {
                     "trip_id": itinerary["id"],
                     "route_id": route_master["id"],
                     "service_id": "always",
                     "shape_id": shape_id,
+                    "average_speed": average_speed,
                 }
                 gtfs_data["trips"].append(trip)
 

--- a/subways/processors/mapsme.py
+++ b/subways/processors/mapsme.py
@@ -14,6 +14,7 @@ from subways.osm_element import el_center
 from subways.structure.station import Station
 from subways.types import IdT, LonLat, OsmElementT, TransfersT
 from ._common import (
+    DEFAULT_AVE_VEHICLE_SPEED,
     DEFAULT_INTERVAL,
     format_colour,
     KMPH_TO_MPS,
@@ -29,7 +30,6 @@ if typing.TYPE_CHECKING:
 OSM_TYPES = {"n": (0, "node"), "w": (2, "way"), "r": (3, "relation")}
 ENTRANCE_PENALTY = 60  # seconds
 SPEED_TO_ENTRANCE = 5 * KMPH_TO_MPS  # m/s
-SPEED_ON_LINE = 40 * KMPH_TO_MPS  # m/s
 
 # (stoparea1_uid, stoparea2_uid) -> seconds; stoparea1_uid < stoparea2_uid
 TransferTimesT: TypeAlias = dict[tuple[int, int], int]
@@ -258,7 +258,7 @@ def transit_data_to_mapsme(
                     itin.append(
                         [
                             uid(stop.stoparea.id),
-                            round(stop.distance / SPEED_ON_LINE),
+                            round(stop.distance / DEFAULT_AVE_VEHICLE_SPEED),
                         ]
                     )
                     # Make exits from platform nodes,

--- a/subways/structure/route_master.py
+++ b/subways/structure/route_master.py
@@ -7,8 +7,8 @@ from typing import TypeVar
 from subways.consts import MAX_DISTANCE_STOP_TO_LINE
 from subways.css_colours import normalize_colour
 from subways.geom_utils import distance, project_on_line
-from subways.osm_element import el_id
-from subways.structure.route import Route
+from subways.osm_element import el_id, get_network
+from subways.structure.route import get_route_duration, get_route_interval
 from subways.structure.stop_area import StopArea
 from subways.types import IdT, OsmElementT
 
@@ -26,7 +26,7 @@ class RouteMaster:
     def __init__(self, city: City, master: OsmElementT = None) -> None:
         self.city = city
         self.routes = []
-        self.best: Route = None
+        self.best: Route = None  # noqa: F821
         self.id: IdT = el_id(master)
         self.has_master = master is not None
         self.interval_from_master = False
@@ -46,13 +46,14 @@ class RouteMaster:
                 )
             except ValueError:
                 self.infill = None
-            self.network = Route.get_network(master)
+            self.network = get_network(master)
             self.mode = master["tags"].get(
                 "route_master", None
             )  # This tag is required, but okay
             self.name = master["tags"].get("name", None)
-            self.interval = Route.get_interval(master["tags"])
+            self.interval = get_route_interval(master["tags"])
             self.interval_from_master = self.interval is not None
+            self.duration = get_route_duration(master["tags"])
         else:
             self.ref = None
             self.colour = None
@@ -61,6 +62,7 @@ class RouteMaster:
             self.mode = None
             self.name = None
             self.interval = None
+            self.duration = None
 
     def stopareas(self) -> Iterator[StopArea]:
         yielded_stopareas = set()
@@ -70,7 +72,7 @@ class RouteMaster:
                     yield stoparea
                     yielded_stopareas.add(stoparea)
 
-    def add(self, route: Route) -> None:
+    def add(self, route: Route) -> None:  # noqa: F821
         if not self.network:
             self.network = route.network
         elif route.network and route.network != self.network:
@@ -148,10 +150,10 @@ class RouteMaster:
         ):
             self.best = route
 
-    def get_meaningful_routes(self) -> list[Route]:
+    def get_meaningful_routes(self) -> list[Route]:  # noqa: F821
         return [route for route in self if len(route) >= 2]
 
-    def find_twin_routes(self) -> dict[Route, Route]:
+    def find_twin_routes(self) -> dict[Route, Route]:  # noqa: F821
         """Two non-circular routes are twins if they have the same end
         stations and opposite directions, and the number of stations is
         the same or almost the same. We'll then find stops that are present
@@ -325,7 +327,11 @@ class RouteMaster:
                 break
         return common_subsequence
 
-    def alert_twin_routes_differ(self, route1: Route, route2: Route) -> None:
+    def alert_twin_routes_differ(
+        self,
+        route1: Route,  # noqa: F821
+        route2: Route,  # noqa: F821
+    ) -> None:
         """Arguments are that route1.id < route2.id"""
         (
             stops_missing_from_route1,
@@ -382,7 +388,10 @@ class RouteMaster:
                 )
 
     @staticmethod
-    def calculate_twin_routes_diff(route1: Route, route2: Route) -> tuple:
+    def calculate_twin_routes_diff(
+        route1: Route,  # noqa: F821
+        route2: Route,  # noqa: F821
+    ) -> tuple:
         """Wagner–Fischer algorithm for stops diff in two twin routes."""
 
         stops1 = route1.stops
@@ -450,10 +459,10 @@ class RouteMaster:
     def __len__(self) -> int:
         return len(self.routes)
 
-    def __getitem__(self, i) -> Route:
+    def __getitem__(self, i) -> Route:  # noqa: F821
         return self.routes[i]
 
-    def __iter__(self) -> Iterator[Route]:
+    def __iter__(self) -> Iterator[Route]:  # noqa: F821
         return iter(self.routes)
 
     def __repr__(self) -> str:

--- a/subways/tests/assets/tiny_world.osm
+++ b/subways/tests/assets/tiny_world.osm
@@ -187,9 +187,10 @@
     <member type='relation' ref='9' role='' />
     <tag k='colour' v='brown' />
     <tag k='colour:infill' v='white' />
+    <tag k='duration' v='5' />
+    <tag k='name' v='LR Line' />
     <tag k='network' v='network-2' />
     <tag k='ref' v='LR' />
-    <tag k='name' v='LR Line' />
     <tag k='route_master' v='light_rail' />
     <tag k='type' v='route_master' />
   </relation>
@@ -198,6 +199,7 @@
     <member type='node' ref='5' role='' />
     <member type='node' ref='6' role='' />
     <member type='way' ref='2' role='' />
+    <tag k='duration' v='10' />
     <tag k='name' v='2 forward' />
     <tag k='ref' v='2' />
     <tag k='route' v='subway' />
@@ -208,6 +210,7 @@
     <member type='node' ref='5' role='' />
     <member type='node' ref='4' role='' />
     <member type='way' ref='2' role='' />
+    <tag k='duration:peak' v='8' />
     <tag k='name' v='2 backward' />
     <tag k='ref' v='2' />
     <tag k='route' v='subway' />
@@ -217,18 +220,18 @@
     <member type='relation' ref='13' role='' />
     <member type='relation' ref='12' role='' />
     <tag k='colour' v='red' />
+    <tag k='name' v='Red Line' />
     <tag k='network' v='network-1' />
     <tag k='ref' v='2' />
-    <tag k='name' v='Red Line' />
     <tag k='route_master' v='subway' />
     <tag k='type' v='route_master' />
   </relation>
   <relation id='15' visible='true' version='1'>
     <member type='relation' ref='8' role='' />
     <member type='relation' ref='7' role='' />
+    <tag k='name' v='Blue Line' />
     <tag k='network' v='network-1' />
     <tag k='ref' v='1' />
-    <tag k='name' v='Blue Line' />
     <tag k='route_master' v='subway' />
     <tag k='type' v='route_master' />
   </relation>

--- a/subways/tests/assets/tiny_world_gtfs/trips.txt
+++ b/subways/tests/assets/tiny_world_gtfs/trips.txt
@@ -1,7 +1,7 @@
-route_id,service_id,trip_id,trip_headsign,trip_short_name,direction_id,block_id,shape_id,wheelchair_accessible,trip_route_type,route_pattern_id,bikes_allowed
-r15,always,r7,,,,,7,,,,
-r15,always,r8,,,,,8,,,,
-r14,always,r12,,,,,12,,,,
-r14,always,r13,,,,,13,,,,
-r11,always,r9,,,,,9,,,,
-r11,always,r10,,,,,10,,,,
+route_id,service_id,trip_id,trip_headsign,trip_short_name,direction_id,block_id,shape_id,wheelchair_accessible,trip_route_type,route_pattern_id,bikes_allowed,average_speed
+r15,always,r7,,,,,7,,,,,40.0
+r15,always,r8,,,,,8,,,,,40.0
+r14,always,r12,,,,,12,,,,,9.4
+r14,always,r13,,,,,13,,,,,11.8
+r11,always,r9,,,,,9,,,,,6.5
+r11,always,r10,,,,,10,,,,,6.5

--- a/subways/tests/sample_data_for_outputs.py
+++ b/subways/tests/sample_data_for_outputs.py
@@ -163,6 +163,7 @@ metro_samples = [
               "start_time": null,
               "end_time": null,
               "interval": null,
+              "duration": null,
               "stops": [
                 {
                   "stoparea_id": "n1",
@@ -197,6 +198,7 @@ metro_samples = [
               "start_time": null,
               "end_time": null,
               "interval": null,
+              "duration": null,
               "stops": [
                 {
                   "stoparea_id": "r3",
@@ -237,6 +239,7 @@ metro_samples = [
               "start_time": null,
               "end_time": null,
               "interval": null,
+              "duration": 600,
               "stops": [
                 {
                   "stoparea_id": "n4",
@@ -267,6 +270,7 @@ metro_samples = [
               "start_time": null,
               "end_time": null,
               "interval": null,
+              "duration": 480,
               "stops": [
                 {
                   "stoparea_id": "n6",
@@ -313,6 +317,7 @@ metro_samples = [
               "start_time": null,
               "end_time": null,
               "interval": null,
+              "duration": 300,
               "stops": [
                 {
                   "stoparea_id": "r4",
@@ -339,6 +344,7 @@ metro_samples = [
               "start_time": null,
               "end_time": null,
               "interval": null,
+              "duration": 300,
               "stops": [
                 {
                   "stoparea_id": "r16",

--- a/subways/tests/test_route.py
+++ b/subways/tests/test_route.py
@@ -1,0 +1,141 @@
+from unittest import TestCase
+
+from subways.structure.route import (
+    get_interval_in_seconds_from_tags,
+    osm_interval_to_seconds,
+    parse_time_range,
+)
+
+
+class TestTimeIntervalsParsing(TestCase):
+    def test__osm_interval_to_seconds__invalid_value(self) -> None:
+        intervals = (
+            ["", "abc", "x30", "30x", "3x0"]
+            + ["5:", ":5", "01:05:", ":01:05", "01:01:00:", ":01:01:00"]
+            + ["01x:05", "01:x5", "x5:01:00", "01:0x:00", "01:01:x"]
+            + ["-5", "01:-05", "-01:05", "-01:00:00", "01:-01:00", "01:01:-01"]
+            + ["0", "00:00", "00:00:00"]
+            + ["00:60", "01:00:60", "01:60:00"]
+            + ["01:60:61", "01:61:60", "01:61:61"]
+        )
+        for interval in intervals:
+            with self.subTest(msg=f"value='{interval}'"):
+                self.assertIsNone(osm_interval_to_seconds(interval))
+
+    def test__osm_interval_to_seconds__valid_value(self) -> None:
+        intervals = {
+            "5": 300,
+            "65": 3900,
+            "10:55": 39300,
+            "02:02:02": 7322,
+            "2:2:2": 7322,
+            "00:59": 3540,
+            "01:00": 3600,
+            "00:00:50": 50,
+            "00:10:00": 600,
+            "01:00:00": 3600,
+        }
+
+        for interval_str, interval_sec in intervals.items():
+            with self.subTest(msg=f"value='{interval_str}'"):
+                self.assertEqual(
+                    interval_sec, osm_interval_to_seconds(interval_str)
+                )
+
+    def test__parse_time_range__invalid_values(self) -> None:
+        ranges = (
+            ["", "a", "ab:cd-ab:cd", "1", "1-2", "01-02"]
+            + ["24/8", "24/7/365"]
+            + ["1:00-02:00", "01:0-02:00", "01:00-2:00", "01:00-02:0"]
+            + ["1x:00-02:00", "01:0x-02:00", "01:00-1x:00", "01:00-02:ab"]
+            + ["-1:00-02:00", "01:-1-02:00", "01:00--2:00", "01:00-02:-1"]
+            + ["01;00-02:00", "01:00-02;00", "01:00=02:00"]
+            + ["01:00-#02:00", "01:00 - 02:00"]
+            + ["01:60-02:05", "01:00-01:61"]
+        )
+        for r in ranges:
+            with self.subTest(msg=f"value='{r}'"):
+                self.assertIsNone(parse_time_range(r))
+
+    def test__parse_time_range__valid_values(self) -> None:
+        ranges = (
+            ["24/7"]
+            + ["00:00-00:00", "00:01-00:02"]
+            + ["01:00-02:00", "02:01-01:02"]
+            + ["02:00-26:59", "12:01-13:59"]
+            + ["Mo-Fr 06:00-21:30", "06:00-21:30 (weekdays)"]
+            + ["Mo-Fr 06:00-21:00; Sa-Su 07:00-20:00"]
+        )
+        answers = [
+            ((0, 0), (24, 0)),
+            ((0, 0), (0, 0)),
+            ((0, 1), (0, 2)),
+            ((1, 0), (2, 0)),
+            ((2, 1), (1, 2)),
+            ((2, 0), (26, 59)),
+            ((12, 1), (13, 59)),
+            ((6, 0), (21, 30)),
+            ((6, 0), (21, 30)),
+            ((6, 0), (21, 0)),
+        ]
+
+        for r, answer in zip(ranges, answers):
+            with self.subTest(msg=f"value='{r}'"):
+                self.assertTupleEqual(answer, parse_time_range(r))
+
+
+class TestRouteIntervals(TestCase):
+    def test__get_interval_in_seconds_from_tags__one_key(self) -> None:
+        cases = [
+            {"tags": {}, "answer": None},
+            {"tags": {"a": "1"}, "answer": None},
+            {"tags": {"duration": "1"}, "answer": 60},
+            {"tags": {"durationxxx"}, "answer": None},
+            {"tags": {"xxxduration"}, "answer": None},
+            # prefixes not considered
+            {"tags": {"ru:duration"}, "answer": None},
+            # suffixes considered
+            {"tags": {"duration:peak": "1"}, "answer": 60},
+            # bare tag has precedence over suffixed version
+            {"tags": {"duration:peak": "1", "duration": "2"}, "answer": 120},
+            # first suffixed version apply
+            {"tags": {"duration:y": "1", "duration:x": "2"}, "answer": 60},
+            # other tags present
+            {"tags": {"a": "x", "duration": "1", "b": "y"}, "answer": 60},
+        ]
+
+        for case in cases:
+            with self.subTest(msg=f"{case['tags']}"):
+                self.assertEqual(
+                    case["answer"],
+                    get_interval_in_seconds_from_tags(
+                        case["tags"], "duration"
+                    ),
+                )
+
+    def test__get_interval_in_seconds_from_tags__several_keys(self) -> None:
+        keys = ("interval", "headway")
+        cases = [
+            {"tags": {}, "answer": None},
+            # prefixes not considered
+            {"tags": {"ru:interval"}, "answer": None},
+            {"tags": {"interval": "1"}, "answer": 60},
+            {"tags": {"headway": "1"}, "answer": 60},
+            {"tags": {"interval": "1", "headway": "2"}, "answer": 60},
+            #  interval has precedence due to its position in 'keys'
+            {"tags": {"headway": "2", "interval": "1"}, "answer": 60},
+            #  non-suffixed keys has precedence
+            {"tags": {"interval:peak": "1", "headway": "2"}, "answer": 120},
+            # among suffixed versions, first key in 'keys' is used first
+            {
+                "tags": {"headway:peak": "2", "interval:peak": "1"},
+                "answer": 60,
+            },
+        ]
+
+        for case in cases:
+            with self.subTest(msg=f"{case['tags']}"):
+                self.assertEqual(
+                    case["answer"],
+                    get_interval_in_seconds_from_tags(case["tags"], keys),
+                )


### PR DESCRIPTION
Process "duration" tag for OSM route/route_master. Take it into account for calculation vehicle timing for mapsme output format; save average speed in GTFS custom column in `trips.txt`.