### PR TITLE
Upgrade shapely to 2.0.4

### DIFF
--- a/tools/make_poly/requirements.txt
+++ b/tools/make_poly/requirements.txt
@@ -1,1 +1,4 @@
-shapely==2.0.1
+shapely==2.0.4
+
+# Fixate versions of indirect requirements
+NumPy==2.0.0


### PR DESCRIPTION
Recently, **NumPy 2.0.0** has been released  which is incompatible with 1.x.x; the **shapely 2.0.1** has a dependency of the form **numpy>=1.14**, so in a newly created virtual environment we've got an incompatible bundle `shalely==2.0.1 + numpy==2.0.0`.

In this PR the shapely is upgrade to 2.0.4 which supports NumPy 2.0.0, and indirect dependencies are fixated in `requirements.txt`.