### PR TITLE
Keey ways (tracks information) in created json

### DIFF
--- a/scripts/process_subways.sh
+++ b/scripts/process_subways.sh
@@ -237,10 +237,12 @@ if [ -n "${NEED_FILTER-}" ]; then
   mkdir -p $TMPDIR/osmfilter_temp/
   QRELATIONS="route=subway =light_rail =monorail =train route_master=subway =light_rail =monorail =train public_transport=stop_area =stop_area_group"
   QNODES="railway=station =subway_entrance =train_station_entrance station=subway =light_rail =monorail subway=yes light_rail=yes monorail=yes train=yes"
+  QWAYS="railway=rail =light_rail =subway =narrow_gauge =funicular =monorail"
   "$OSMCTOOLS/osmfilter" "$PLANET_METRO" \
       --keep= \
       --keep-relations="$QRELATIONS" \
       --keep-nodes="$QNODES" \
+      --keep-ways="$QWAYS" \
       --drop-author \
       -t=$TMPDIR/osmfilter_temp/temp \
       -o="$FILTERED_DATA"

--- a/subways/processors/mapsme.py
+++ b/subways/processors/mapsme.py
@@ -310,6 +310,7 @@ def transit_data_to_mapsme(
                         "interval": round(
                             variant.interval or DEFAULT_INTERVAL
                         ),
+                        "tracks": variant.get_tracks_geometry(),
                     }
                 )
             network["routes"].append(routes)


### PR DESCRIPTION
Allows them to be used to create more accurate subway maps

See the corresponding PR in `organicmaps` here: https://github.com/organicmaps/organicmaps/pull/12251

Part of organicmaps/organicmaps#12241

### City of Valencia, Spain
_I pulled data from the Overpass API to test this, I didn't pull the entire production planet-scale pipeline here._

| before | after | 
| ------ | ----- |
| <img width="2516" height="1732" alt="Screen Region 2026-02-24 at 20 59 20" src="https://github.com/user-attachments/assets/d3b6f6cc-9d08-43a4-825b-619f375a0ed2" /> | <img width="2544" height="1754" alt="Screen Region 2026-02-24 at 20 57 36" src="https://github.com/user-attachments/assets/6438d2f3-199e-4b97-b344-fb2ee5c2e2ab" /> |
| <img width="243" height="325" alt="Screen Region 2026-02-24 at 20 59 20 copy" src="https://github.com/user-attachments/assets/c7922a7b-1b86-44ee-808e-c7e80f101c2e" /> | <img width="273" height="342" alt="Screen Region 2026-02-24 at 20 57 36 copy" src="https://github.com/user-attachments/assets/af942c23-277f-418b-bb90-e48fb1030062" /> |

### London, UK

| before | after | 
| ------ | ----- |
| <img width="2598" height="1750" alt="Screen Region 2026-02-24 at 21 29 53" src="https://github.com/user-attachments/assets/4b09d511-6958-4ce4-857b-76ab9e8bfc5a" /> |  <img width="2366" height="1600" alt="Screen Region 2026-02-24 at 21 28 36" src="https://github.com/user-attachments/assets/d035a767-ed6b-42eb-80c2-86ff6ead4ad1" /> |


------
_Below is the claude generated plan_

# Plan: Use real track geometry for transit lines

## Context

The transit layer currently synthesizes Catmull-Rom splines between stops instead of using actual track geometry from OSM. This is suboptimal for all transit types — subway lines have real track geometry in OSM (`route=subway` relations contain `railway=subway` way members), and using it would improve rendering accuracy at curves, junctions, and line divergence points. This is also a prerequisite for adding tram support (see `PLAN_TRAM_SUPPORT.md`), since surface tram lines absolutely must follow their actual street routes.

## Background: Why track geometry hasn't been used until now

The subways repo has **two separate output processors**:

- **`_common.py` / `transit_to_dict()`** — the generic processor used by GTFS and GeoJSON outputs. It **already includes track geometry**:
  ```python
  "tracks": route.get_tracks_geometry(),  # Already present!
  ```

- **`mapsme.py` / `transit_data_to_mapsme()`** — the Organic Maps-specific processor. It **deliberately omits tracks**, outputting only stops and intervals:
  ```python
  routes["itineraries"].append({
      "stops": itin,
      "interval": round(variant.interval or DEFAULT_INTERVAL),
  })
  # No "tracks" field
  ```

The track extraction code is fully implemented and mature in `route.py`:
- `build_longest_line()` — chains ordered way members from the route relation into a continuous line, handling way reversal and gaps
- `get_extended_tracks()` — amends tracks with leading/trailing stops not projected onto rails
- `get_truncated_tracks()` — trims track beyond first/last stops
- `get_tracks_geometry()` — combines the above

**However**, there's a second gate: `process_subways.sh` line 240 runs osmfilter with **no `--keep-ways` parameter**, so all ways are stripped from the data before the Python code even runs. The `build_longest_line()` method silently gets no way data and produces empty tracks.

The Overpass API path (used for small runs of < 10 cities via `(._;>>;)`) DOES recursively download all members including ways, so tracks work there. It's only the planet-scale osmfilter pipeline that strips them.

Hypothesis: The original `transit_graph_generator.py` (Organic Maps repo) was designed as a self-contained geometry generator using Catmull-Rom curves, and the mapsme processor was intentionally kept simpler. Since Catmull-Rom looked "good enough" for underground subways and trams were never supported, nobody connected the existing track geometry code to the Organic Maps output path.

## Changes

### 1. Subways repo: Preserve way geometry through osmfilter

**File:** `scripts/process_subways.sh:240-246`

Add `--keep-ways` to the osmfilter command so that railway way members of route relations are preserved:

```bash
# Before:
"$OSMCTOOLS/osmfilter" "$PLANET_METRO" \
    --keep= \
    --keep-relations="$QRELATIONS" \
    --keep-nodes="$QNODES" \
    --drop-author \
    -t=$TMPDIR/osmfilter_temp/temp \
    -o="$FILTERED_DATA"

# After:
QWAYS="railway=rail =light_rail =subway =narrow_gauge =funicular =monorail"
"$OSMCTOOLS/osmfilter" "$PLANET_METRO" \
    --keep= \
    --keep-relations="$QRELATIONS" \
    --keep-nodes="$QNODES" \
    --keep-ways="$QWAYS" \
    --drop-author \
    -t=$TMPDIR/osmfilter_temp/temp \
    -o="$FILTERED_DATA"
```

This is the key change that unblocks everything. The way geometry extraction code (`route.build_longest_line()` etc.) already works — it just silently produces empty tracks when ways are missing from the input. With ways preserved, `get_tracks_geometry()` will return real coordinates.

**Note:** This will increase the filtered data file size since way geometry is now retained. The QWAYS filter keeps only railway-tagged ways to minimize bloat.

### 2. Subways repo: Add tracks to mapsme processor output

**File:** `subways/processors/mapsme.py:307-314`

Add the tracks field to the itinerary output, matching what `_common.py` already does:

```python
# Before (line 307-314):
routes["itineraries"].append(
    {
        "stops": itin,
        "interval": round(
            variant.interval or DEFAULT_INTERVAL
        ),
    }
)

# After:
routes["itineraries"].append(
    {
        "stops": itin,
        "interval": round(
            variant.interval or DEFAULT_INTERVAL
        ),
        "tracks": variant.get_tracks_geometry(),
    }
)
```

This is a one-line addition. The `get_tracks_geometry()` method already exists and is already used by the `_common.py` processor.

### 3. Organic Maps repo: Use provided track geometry instead of Catmull-Rom curves

See related PR: 